### PR TITLE
Register and merge APIs

### DIFF
--- a/fern/apis/webhooks-v0/definition/api.yml
+++ b/fern/apis/webhooks-v0/definition/api.yml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
+
+name: webhooks-v0

--- a/fern/apis/webhooks-v0/definition/events.yml
+++ b/fern/apis/webhooks-v0/definition/events.yml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
+
+imports:
+  # messages: ../types/messages.yml
+
+types:
+  WebhookId:
+    type: string
+    docs: ID of webhook.
+
+  ClientId:
+    type: string
+    docs: Client ID of webhook.
+
+  Url:
+    type: string
+    docs: URL of webhook endpoint.
+
+  EventType:
+    enum:
+      - name: MESSAGE_RECEIVED
+        value: message.received
+
+  EventId:
+    type: string
+    docs: ID of event.
+
+  MessageReceivedPayload:
+    properties:
+      event_type: EventType
+      event_id: EventId
+      # message: messages.Message
+
+  SvixId:
+    type: string
+    docs: ID of webhook message.
+
+  SvixTimestamp:
+    type: datetime
+    docs: Timestamp of webhook message.
+
+  SvixSignature:
+    type: string
+    docs: Signature of webhook message.
+
+webhooks:
+  messageReceived:
+    display-name: Message Received
+    method: POST
+    headers:
+      svix-id: SvixId
+      svix-signature: SvixSignature
+      svix-timestamp: SvixTimestamp
+    payload: MessageReceivedPayload

--- a/fern/apis/websockets-v0/definition/api.yml
+++ b/fern/apis/websockets-v0/definition/api.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
+
+name: websockets-v0
+
+environments:
+  Production: https://ws.agentmail.to
+  Development: https://ws.agentmail.dev
+
+default-environment: Production

--- a/fern/apis/websockets-v0/definition/websockets.yml
+++ b/fern/apis/websockets-v0/definition/websockets.yml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
+
+imports:
+  # messages: ../types/messages.yml
+
+types:
+  EventId:
+    type: string
+    docs: ID of event.
+
+  SubscribeEvent:
+    properties:
+      type: literal<"subscribe">
+      inbox_ids:
+        type: list<string>
+        docs: IDs of the inboxes to subscribe to.
+
+  SubscribedEvent:
+    properties:
+      type: literal<"subscribed">
+      inbox_ids:
+        type: list<string>
+        docs: IDs of the inboxes that have been subscribed to.
+
+  MessageReceivedEvent:
+    properties:
+      type: literal<"event">
+      event_type: literal<"message.received">
+      event_id: EventId
+      # message: messages.Message
+
+channel:
+  path: /v0
+  display-name: Endpoint
+  auth: true
+  query-parameters:
+    auth_token:
+      type: string
+      docs: API key of the client.
+  messages:
+    subscribe:
+      origin: client
+      body: SubscribeEvent
+    subscribed:
+      origin: server
+      body: SubscribedEvent
+    message_received:
+      origin: server
+      body: MessageReceivedEvent

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -182,7 +182,12 @@ navigation:
   - tab: api
     layout:
       - api: API Reference
+        api-name: api-v0
         summary: pages/apiwelcome.mdx
         snippets:
           python: agentmail
           typescript: agentmail
+      - api: Webhooks Reference
+        api-name: webhooks-v0
+      - api: Websockets Reference
+        api-name: websockets-v0


### PR DESCRIPTION
I want to:
1. Register `api-v0` so that I can import the `Message` type in `webhooks-v0` and `websockets-v0`
2. Merge the 3 APIs in to 1 SDK