### PR TITLE
fix(docs): normalize code block indentation and formatting

### DIFF
--- a/fern/pages/core-concepts/attachments.mdx
+++ b/fern/pages/core-concepts/attachments.mdx
@@ -18,7 +18,7 @@ To send a file, you include it in an `Attachments` array when sending a `Message
 - **`content_type`** (optional): The MIME type of the file (e.g., `application/pdf`).
 
 <CodeBlocks>
-```python title="Python"
+```python
 import base64
 
 # A simple text file for this example
@@ -74,7 +74,7 @@ The API response for getting an attachment is the raw file itself, which you can
 If you know the `Message` an `Attachment` belongs to, you can retrieve it directly.
 
 <CodeBlocks>
-```python title="Python"
+```python
 inbox_id = "inbox_123"
 message_id = "msg_456"
 attachment_id = "attach_789" # From the message object
@@ -88,7 +88,7 @@ file_data = client.inboxes.messages.attachments.get(
 # Now you can save the file
 
 with open("downloaded_file.pdf", "wb") as f:
-f.write(file_data)
+    f.write(file_data)
 
 ````
 
@@ -116,15 +116,15 @@ const fileData = await client.inboxes.messages.attachments.get(
 Similarly, you can retrieve an `Attachment` if you know the `Thread` it's in, which can be more convenient for multi-message conversations.
 
 <CodeBlocks>
-```python title="Python"
+```python
 inbox_id = "inbox_123"
 thread_id = "thread_abc"
 attachment_id = "attach_789" # From a message within the thread
 
 file_data = client.inboxes.threads.attachments.get(
-inbox_id=inbox_id,
-thread_id=thread_id,
-attachment_id=attachment_id
+    inbox_id=inbox_id,
+    thread_id=thread_id,
+    attachment_id=attachment_id
 )
 
 ````

--- a/fern/pages/core-concepts/drafts.mdx
+++ b/fern/pages/core-concepts/drafts.mdx
@@ -26,7 +26,7 @@ You can interact with `Drafts` throughout their lifecycle, from creation to the 
 This is the first step. You create a `Draft` in a specific `Inbox` that will eventually be the sender.
 
 <CodeBlocks>
-```python title="Python"
+```python
 # You'll need an inbox ID to create a draft in.
 
 new_draft=client.inboxes.drafts.create(

--- a/fern/pages/core-concepts/inboxes.mdx
+++ b/fern/pages/core-concepts/inboxes.mdx
@@ -95,9 +95,9 @@ const client = new AgentMailClient({ apiKey: "YOUR_API_KEY" });
 // --- Create an Inbox ---
 // Creates a new inbox with a default agentmail.to domain
 await client.inboxes.create({
-  username: docs-testing,
-  domain: domain.com,
-  displayName: Docs Tester,
+  username: “docs-testing”,
+  domain: “domain.com”,
+  displayName: “Docs Tester”,
 });
 console.log(`Created Inbox: ${newInbox.id}`);
 

--- a/fern/pages/core-concepts/labels.mdx
+++ b/fern/pages/core-concepts/labels.mdx
@@ -72,7 +72,7 @@ const sentMessage = await client.inboxes.messages.send(
 You can modify the `Labels` on a `Message` that has already been sent using the `update` (PATCH) method. This is perfect for changing the state of a conversation as your agent works on it.
 
 <CodeBlocks>
-```python title="Python"
+```python
 # Let's add a 'resolved' label to a message
 
 client.messages.update(
@@ -89,16 +89,16 @@ client.messages.update(
 
 
 await client.inboxes.messages.update(
-	"my_inbox@domain.com",
-	"msg_id_123",
-	{
-		addLabels: [
-				"resolved"
-		],
-		removeLabels: [
-				"unresolved"
-		]
-	}
+  "my_inbox@domain.com",
+  "msg_id_123",
+  {
+    addLabels: [
+        "resolved"
+    ],
+    removeLabels: [
+        "unresolved"
+    ]
+  }
 )
 
 ````
@@ -110,14 +110,14 @@ await client.inboxes.messages.update(
 This is where `Labels` become truly powerful. You can list `Threads`, `Messages`, and `Drafts` by filtering for one or more `Labels`, allowing you to create highly targeted queries.
 
 <CodeBlocks>
-```python title="Python"
+```python
 # Find all threads from a specific campaign that need a follow-up
 client.inboxes.threads.list(
     inbox_id = 'outbound-agent@domain.com',
-	labels=[
-		"q4-campaign",
-		"follow_up"
-	]
+    labels=[
+        "q4-campaign",
+        "follow_up"
+    ]
 )
 
 print(f"Found {len(filtered_threads)} threads that need a follow-up.")
@@ -127,13 +127,13 @@ print(f"Found {len(filtered_threads)} threads that need a follow-up.")
 ```typescript title="TypeScript"
 // Find all threads from a specific campaign that need a follow-up
 await client.inboxes.threads.list(
-	"leads@agentmail.to",
-	{
-		labels: [
-			"q4-campaign",
-			"follow_up"
-		]
-	}
+  "leads@agentmail.to",
+  {
+    labels: [
+      "q4-campaign",
+      "follow_up"
+    ]
+  }
 )
 
 

--- a/fern/pages/core-concepts/messages.mdx
+++ b/fern/pages/core-concepts/messages.mdx
@@ -9,7 +9,7 @@ description: Learn how to send, receive, and manage emails as Message objects wi
 
 In the AgentMail ecosystem, a `Message` is the API-first representation of a traditional email. It's a structured object containing all the elements you'd expect: a sender, recipients, a subject line, and the body of the email.
 
-Every `Message` lives inside a `Thread` to keep conversations organized. When you send a new `Message`, a new `Thread` is created. When you reply, the new `Message` is added to the existing `Thread`. Literally a normal email thread as we now it.
+Every `Message` lives inside a `Thread` to keep conversations organized. When you send a new `Message`, a new `Thread` is created. When you reply, the new `Message` is added to the existing `Thread`. Literally a normal email thread as we know it.
 
 One of the powerful features of AgentMail is the ability to seamlessly include humans in agent-driven conversations. You can `cc` or `bcc` a real person on any message your agent sends, creating a "human-in-the-loop" workflow for oversight, escalations, or quality assurance.
 
@@ -41,21 +41,21 @@ const client = new AgentMailClient({ apiKey: "YOUR_API_KEY" });
 To start a new conversation, you can send a `Message` from one of your inboxes. This action will create a new `Thread` and return the `Message` object.
 
 <CodeBlocks>
-```python title="Python"
+```python
 # You'll need an inbox ID to send from.
 # Let's assume we have one:
 
 sent_message = client.inboxes.messages.send(
-inbox_id = 'my_inbox@domain.com',
-to = 'recipient@domain.com',
-labels=[
-"outreach",
-"startup"
-],
-subject="[YC S25] Founder Reachout ",
-text="Hello, I'm Michael, and I'm a founder at AgentMail...",
-html="<div dir=\"ltr\">Hello,<br><br>I'm Michael, and I'm a founder at AgentMail...")
-
+    inbox_id = 'my_inbox@domain.com',
+    to = 'recipient@domain.com',
+    labels=[
+        "outreach",
+        "startup"
+    ],
+    subject="[YC S25] Founder Reachout ",
+    text="Hello, I'm Michael, and I'm a founder at AgentMail...",
+    html="<div dir=\"ltr\">Hello,<br><br>I'm Michael, and I'm a founder at AgentMail..."
+)
 print(f"Message sent successfully with ID: {sent_message.message_id}")
 
 ````
@@ -65,11 +65,11 @@ print(f"Message sent successfully with ID: {sent_message.message_id}")
 const sentMessage = await client.inboxes.messages.send(
 	"outreach@agentmail.to", // this is your inbox you are trying to send from
 	{
-    to: receipent@domain.com
+    to: recipent@domain.com
 		labels: [
 				"outreach",
 				"startup"
-			],
+		],
 		subject: "[YC S25] Founder Reachout ",
 		text: "Hello, I'm Michael, and I'm a founder at AgentMail...",
 		html: "<div dir=\"ltr\">Hello,<br><br>I'm Michael, and I'm a founder at AgentMail..."
@@ -86,8 +86,7 @@ console.log(`Message sent successfully with ID: ${sentMessage.id}`);
 You can retrieve a list of all `Messages` within a specific `Inbox`. This is useful for getting a history of all correspondence.
 
 <CodeBlocks>
-```python title="Python"
-
+```python
 all_messages = client.inboxes.messages.list(inbox_id='my_inbox@agentmail.to')
 
 print(f"Found {all_messages.count} messages in the inbox.")
@@ -112,8 +111,8 @@ allMessages.forEach((message) => {
 Replying to an existing `Message` adds your new `Message` to the same `Thread`, keeping the conversation organized.
 
 <CodeBlocks>
-```python title="Python" wordWrap
-
+```python
+# Python example
 reply = client.inboxes.messages.reply(
     inbox_id='my_inbox@domain.com'
     message_id='msg_id',
@@ -137,10 +136,10 @@ const reply = await client.inboxes.messages.reply(
 	{
 		text: "Thanks for the referral!",
 		attachments: [
-				{
-					content: "resume"
-				}
-			]
+			{
+				content: "resume"
+			}
+		]
 	}
 )
 

--- a/fern/pages/core-concepts/threads.mdx
+++ b/fern/pages/core-concepts/threads.mdx
@@ -79,13 +79,13 @@ console.log(`Found ${allThreads.length} threads across the entire organization.`
 You can also retrieve a single `Thread` by its ID. This will return the `Thread` object, which typically contains a list of all its associated `Messages` and their ID's. A common workflow is listing the messages in a thread and calling the `messages.reply` method on the last one.
 
 <CodeBlocks>
-```python title="Python"
+```python
 thread_id = "thread_456def"
 
 # This retrieves a single thread and its messages
 
 thread = client.threads.get(
-thread_id="thread_id"
+    thread_id="thread_id"
 )
 
 print(f"Retrieved thread {thread.id} with {len(thread.messages)} messages.")

--- a/fern/pages/examples/github-star-agent.mdx
+++ b/fern/pages/examples/github-star-agent.mdx
@@ -64,7 +64,8 @@ First, let's set up your project directory and install the necessary dependencie
 Create a file named `main.py` and add the full code example you provided. This script contains all the logic for our agent, including the new logic to idempotently create the inbox it needs.
 
 <CodeBlocks>
-```python main.py
+```python
+# main.py
 from dotenv import load_dotenv
 load_dotenv()
 
@@ -87,15 +88,15 @@ inbox = f"{inbox_username}@agentmail.to"
 
 target_github_repo = os.getenv("TARGET_GITHUB_REPO")
 if not target_github_repo:
-print("\nWARNING: The TARGET_GITHUB_REPO environment variable is not set.")
-print("The agent will not have a specific GitHub repository to focus on.")
-print("Please set it in your .env file (e.g., TARGET_GITHUB_REPO='owner/repository_name')\n")
+    print("\nWARNING: The TARGET_GITHUB_REPO environment variable is not set.")
+    print("The agent will not have a specific GitHub repository to focus on.")
+    print("Please set it in your .env file (e.g., TARGET_GITHUB_REPO='owner/repository_name')\n")
 
 demo_target_email = os.getenv("DEMO_TARGET_EMAIL")
 if not demo_target_email:
-print("\nWARNING: The DEMO_TARGET_EMAIL environment variable is not set.")
-print("The agent will not have a specific email to send the 'top starrer' outreach to.")
-print("Please set it in your .env file (e.g., DEMO_TARGET_EMAIL='your.email@example.com')\n")
+    print("\nWARNING: The DEMO_TARGET_EMAIL environment variable is not set.")
+    print("The agent will not have a specific email to send the 'top starrer' outreach to.")
+    print("Please set it in your .env file (e.g., DEMO_TARGET_EMAIL='your.email@example.com')\n")
 
 # Determine the target email, with a fallback if the environment variable is not set.
 
@@ -122,13 +123,13 @@ client = AgentMail()
 inbox_client_id = f"inbox-for-{inbox_username}"
 print(f"Attempting to create or retrieve inbox '{inbox}' with client_id: {inbox_client_id}")
 try:
-client.inboxes.create(
-username=inbox_username,
-client_id=inbox_client_id
-)
-print("Inbox creation/retrieval successful.")
+    client.inboxes.create(
+        username=inbox_username,
+        client_id=inbox_client_id
+    )
+    print("Inbox creation/retrieval successful.")
 except Exception as e:
-print(f"Error creating/retrieving inbox: {e}") # Depending on the desired behavior, you might want to exit here # if the inbox is critical for the agent's function.
+    print(f"Error creating/retrieving inbox: {e}") # Depending on the desired behavior, you might want to exit here # if the inbox is critical for the agent's function.
 
 # 3. Start the ngrok tunnel to get a public URL
 
@@ -142,13 +143,13 @@ webhook_url = f"{listener.url()}/webhooks"
 webhook_client_id = f"webhook-for-{inbox_username}"
 print(f"Attempting to create or retrieve webhook for URL: {webhook_url}")
 try:
-client.webhooks.create(
-url=webhook_url,
-client_id=webhook_client_id,
-)
-print("Webhook creation/retrieval successful.")
+    client.webhooks.create(
+        url=webhook_url,
+        client_id=webhook_client_id,
+    )
+    print("Webhook creation/retrieval successful.")
 except Exception as e:
-print(f"Error creating/retrieving webhook: {e}")
+    print(f"Error creating/retrieving webhook: {e}")
 
 # 5. Initialize the Flask App
 
@@ -204,9 +205,9 @@ Remember, your primary contact for ongoing conversation is '{actual_demo_target_
 """
 
 agent = Agent(
-name="GitHub Agent",
-instructions=instructions,
-tools=AgentMailToolkit(client).get_tools() + [WebSearchTool()],
+    name="GitHub Agent",
+    instructions=instructions,
+    tools=AgentMailToolkit(client).get_tools() + [WebSearchTool()],
 )
 
 messages = []
@@ -218,8 +219,8 @@ MAX_SIMULATED_STARS = 1 # single star even
 stars_found_so_far = 0
 
 def poll_github_stargazers():
-global simulated_stargazer_count, stars_found_so_far
-print(f"GitHub polling thread started for top 20 repositories related to AI agents...")
+    global simulated_stargazer_count, stars_found_so_far
+    print(f"GitHub polling thread started for top 20 repositories related to AI agents...")
 
     # Give the Flask app a moment to start up if run concurrently
     time.sleep(3)
@@ -257,10 +258,10 @@ print(f"GitHub polling thread started for top 20 repositories related to AI agen
             The email MUST end with a call to action like: "<p>I'm an AI assistant for '{actual_target_github_repo}', and I'm here to help answer any questions you might have. Feel free to reply to this email with your thoughts or if there's anything specific you'd like to know!</p>"
 
             The parameters for the 'send_message' tool call should be:
-               - 'to': ['{actual_demo_target_email}']
-               - 'inbox_id': '{inbox}'
-               - 'subject': An engaging subject based on the web search findings (e.g., "Insights on {actual_target_github_repo} for Your AI Projects!").
-               - 'html': An email body in HTML format, adhering to all the above content and formatting rules (mention star, no direct links, specific CTA).
+                - 'to': ['{actual_demo_target_email}']
+                - 'inbox_id': '{inbox}'
+                - 'subject': An engaging subject based on the web search findings (e.g., "Insights on {actual_target_github_repo} for Your AI Projects!").
+                - 'html': An email body in HTML format, adhering to all the above content and formatting rules (mention star, no direct links, specific CTA).
 
             Your output for this step MUST be an action call to 'send_message' with the tool input formatted as a valid JSON string, ensuring you use the 'html' field for the body. For example:
             Action: send_message(```
@@ -293,23 +294,22 @@ print(f"GitHub polling thread started for top 20 repositories related to AI agen
 
 @app.route("/webhooks", methods=["POST"])
 def receive_webhook():
-print(f"\n[/webhooks] Received webhook. Payload keys: {list(request.json.keys()) if request.is_json else 'Not JSON or empty'}")
-Thread(target=process_webhook, args=(request.json,)).start()
-return Response(status=200)
+    print(f"\n[/webhooks] Received webhook. Payload keys: {list(request.json.keys()) if request.is_json else 'Not JSON or empty'}")
+    Thread(target=process_webhook, args=(request.json,)).start()
+    return Response(status=200)
 
 def process_webhook(payload):
-global messages
+    global messages
 
     email = payload["message"]
     print(f"[process_webhook] Processing email from: {email.get('from')}, subject: {email.get('subject')}, id: {email.get('message_id')}")
 
     prompt = f"""
-
-From: {email["from"]}
-Subject: {email["subject"]}
-Body:\n{email["text"]}
-"""
-print("Prompt:\n\n", prompt, "\n")
+            From: {email["from"]}
+            Subject: {email["subject"]}
+            Body:\n{email["text"]}
+            """
+    print("Prompt:\n\n", prompt, "\n")
 
     response = asyncio.run(Runner.run(agent, messages + [{"role": "user", "content": prompt}]))
     print("Response:\n\n", response.final_output, "\n")
@@ -321,12 +321,12 @@ print("Prompt:\n\n", prompt, "\n")
     messages = response.to_input_list()
     print(f"[process_webhook] Updated message history. New length: {len(messages)}\n")
 
-if **name** == "**main**":
-print(f"Inbox: {inbox}\n")
-if not target_github_repo or target_github_repo == "example/repo":
-print("WARNING: TARGET_GITHUB_REPO not set or is default. Poller will not be effective.")
-if not demo_target_email:
-print("WARNING: DEMO_TARGET_EMAIL not set or is default. Poller will not be effective.")
+if __name__ == "__main__":
+    print(f"Inbox: {inbox}\n")
+    if not target_github_repo or target_github_repo == "example/repo":
+        print("WARNING: TARGET_GITHUB_REPO not set or is default. Poller will not be effective.")
+    if not demo_target_email:
+        print("WARNING: DEMO_TARGET_EMAIL not set or is default. Poller will not be effective.")
 
     polling_thread = Thread(target=poll_github_stargazers)
     polling_thread.daemon = True # So it exits when the main thread exits

--- a/fern/pages/resources/community.mdx
+++ b/fern/pages/resources/community.mdx
@@ -15,7 +15,7 @@ description: "Connect with the AgentMail team and developers, share what you're 
   </Card>
   <Card
     title="Follow us on X (Twitter)"
-    href="https://twitter.com/agentmail_to"
+    href="https://twitter.com/agentmail"
     icon="fa-brands fa-x-twitter"
   >
     Stay up-to-date with the latest product announcements, community highlights,


### PR DESCRIPTION
This PR fixes inconsistent indentation across Python code blocks in the documentation. It removes problematic fence attributes (`title="Python"` / `wordWrap`) that caused GitHub/Fern rendering issues (merged lines and lost indentation), and standardizes all blocks to use spaces.

All examples are now copy paste runnable without indentation errors.
