### PR TITLE
fix(cli): upgrade version for internal fix

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "agentmail",
-  "version": "0.99.1"
+  "version": "0.101.2"
 }

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "agentmail",
-  "version": "0.101.2"
+  "version": "0.101.3"
 }


### PR DESCRIPTION
Upgrading Fern CLI version to 0.101.3 for internal fix.

This fixes an issue where algolia search and related AI indexing tools were unable to access API definitions due to a minor error in the CLI's recent versions (post 0.95.0).