### PR TITLE
[ENG-310] Reply Extraction Docs

### DIFF
--- a/fern/pages/core-concepts/messages.mdx
+++ b/fern/pages/core-concepts/messages.mdx
@@ -172,6 +172,8 @@ console.log(`Retrieved message with subject: ${message.subject}`);
 ```
 </CodeBlocks>
 
+When receiving replies or forwards, use `extracted_text` or `extracted_html` for just the new content—quoted history is stripped automatically.
+
 ### Crafting Your Message: HTML, Text, and CSS
 
 When sending a `Message`, you can provide the body in two formats: `text` for a plain-text version and `html` for a rich, styled version.

--- a/fern/pages/get-started/quickstart.mdx
+++ b/fern/pages/get-started/quickstart.mdx
@@ -39,6 +39,11 @@ Get your API key from the [Console](https://console.agentmail.to) and replace `a
   ```
 </CodeBlocks>
 
+<Tip>
+  When receiving emails, messages include `extracted_text` and `extracted_html`
+  for reply content without quoted history.
+</Tip>
+
 This guide will walk you through installing the AgentMail SDK, authenticating with your API key, and creating your first email inbox.
 
 <Steps>

--- a/fern/pages/guides/sending-receiving-email.mdx
+++ b/fern/pages/guides/sending-receiving-email.mdx
@@ -85,6 +85,11 @@ Here's the step-by-step logic for a polling-based conversational agent.
         const messageIdToReplyTo = lastMessage.message_id;
         ```
         </CodeBlocks>
+
+        <Tip>
+          Use `last_message.extracted_text` (or `extracted_html`) when you need
+          just the new reply content, without quoted history.
+        </Tip>
     </Step>
     <Step title="3. Send the Reply and Update Labels">
         Now that you have the `message_id` to reply to, you can send your agent's response. It's also a best practice to update the `Labels` on the original `Message` at the same time, removing the `unreplied` `Label` and adding a `replied` `Label` to prevent the agent from replying to the same message twice.

--- a/fern/pages/resources/faq.mdx
+++ b/fern/pages/resources/faq.mdx
@@ -33,6 +33,10 @@ description: "Find answers to common questions about AgentMail, from core concep
     polling the API for new messages. You can learn how to set them up in our
     [Webhooks Overview](/overview).
   </Accordion>
+  <Accordion title="How do I get just the new content from a reply?">
+    Use `extracted_text` or `extracted_html` on the Message object. AgentMail
+    strips quoted text automatically, so you get only the new reply content.
+  </Accordion>
   <Accordion title="How do I make sure I don't end up in spam?">
     Email deliverability is a complex topic. We go in depth in our [Email
     Deliverability best practices guide](/email-deliverability).


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Documented reply extraction (extracted_text and extracted_html) so users can get only new reply content with quoted history removed, aligning with ENG-310. Updates Messages core concept, Quickstart tip, Sending & Receiving guide, and FAQ with clear guidance.

<sup>Written for commit 4e7d23d95a726f3031f7083033e37334b50852ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

