### PR TITLE
feat(docs): add LLM documentation index pointer to all docs pages

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "agentmail",
-  "version": "3.88.0"
+  "version": "4.2.2"
 }

--- a/fern/pages/apiwelcome.mdx
+++ b/fern/pages/apiwelcome.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: API Welcome
 subtitle: Getting Started with AgentMail
 slug: api-reference
 description: Quick overview of the AgentMail SDK
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## Introduction
 

--- a/fern/pages/apiwelcome.mdx
+++ b/fern/pages/apiwelcome.mdx
@@ -5,6 +5,8 @@ slug: api-reference
 description: Quick overview of the AgentMail SDK
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## Introduction
 
 AgentMail provides a powerful API for managing email communications programmatically. Whether you're building automated testing systems, handling customer support workflows, or developing email-based applications, our API offers the tools you need!

--- a/fern/pages/best-practices/email-deliverability.mdx
+++ b/fern/pages/best-practices/email-deliverability.mdx
@@ -5,6 +5,8 @@ slug: email-deliverability
 description: Learn the strategies and best practices for maximizing your email deliverability with AgentMail.
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## What is Email Deliverability?
 
 Email deliverability is the art and science of getting your emails into your recipients' inboxes. It's not just about hitting "send"; it's about building a good reputation with email providers like Gmail and Outlook so they trust that you're sending valuable content, not spam.

--- a/fern/pages/best-practices/email-deliverability.mdx
+++ b/fern/pages/best-practices/email-deliverability.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Email Deliverability
 subtitle: Best practices for landing your emails in the inbox, not the spam folder.
 slug: email-deliverability
 description: Learn the strategies and best practices for maximizing your email deliverability with AgentMail.
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## What is Email Deliverability?
 

--- a/fern/pages/best-practices/idempotency.mdx
+++ b/fern/pages/best-practices/idempotency.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "Idempotent Requests"
 subtitle: "Learn how to use idempotency keys to build safe and reliable API integrations."
 slug: idempotency
 description: "A guide to using the client_id parameter in AgentMail to prevent duplicate resources and safely retry API requests."
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## What is Idempotency?
 

--- a/fern/pages/best-practices/idempotency.mdx
+++ b/fern/pages/best-practices/idempotency.mdx
@@ -5,6 +5,8 @@ slug: idempotency
 description: "A guide to using the client_id parameter in AgentMail to prevent duplicate resources and safely retry API requests."
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## What is Idempotency?
 
 In the context of an API, idempotency is the concept that making the same API request multiple times produces the same result as making it just once. If an idempotent `POST` request to create a resource is sent five times, it only creates the resource on the first call. The next four calls do nothing but return the result of that first successful call.

--- a/fern/pages/core-concepts/attachments.mdx
+++ b/fern/pages/core-concepts/attachments.mdx
@@ -5,6 +5,8 @@ slug: attachments
 description: Learn how to send files as attachments, and download incoming attachments from both messages and threads.
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## What are `Attachments`?
 
 An `Attachment` is a file that is associated with a `Message`. This can be anything from a PDF invoice to a CSV report or an image(though we don't recommend sending images in the first email sent. We go more into this in the [deliverability section](/email-deliverability)). Your agents can both send `Attachments` in outgoing `Messages` and process `Attachments` from incoming `Messages`.

--- a/fern/pages/core-concepts/attachments.mdx
+++ b/fern/pages/core-concepts/attachments.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Attachments
 subtitle: Sending and receiving files with your agents.
 slug: attachments
 description: Learn how to send files as attachments, and download incoming attachments from both messages and threads.
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## What are `Attachments`?
 

--- a/fern/pages/core-concepts/contexts.mdx
+++ b/fern/pages/core-concepts/contexts.mdx
@@ -1,0 +1,2 @@
+<Markdown src="/snippets/llms-index.mdx" />
+

--- a/fern/pages/core-concepts/drafts.mdx
+++ b/fern/pages/core-concepts/drafts.mdx
@@ -5,6 +5,8 @@ slug: drafts
 description: Learn how to create, manage, and send Drafts to enable advanced agent workflows like human-in-the-loop review and scheduled sending.
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## What is a Draft?
 
 A `Draft` is an unsent `Message`. It's a resource that allows your agent to prepare the contents of an email—including recipients, a subject, a body, and `Attachments`—without sending it immediately.

--- a/fern/pages/core-concepts/drafts.mdx
+++ b/fern/pages/core-concepts/drafts.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Drafts
 subtitle: Preparing and scheduling Messages for your agents.
 slug: drafts
 description: Learn how to create, manage, and send Drafts to enable advanced agent workflows like human-in-the-loop review and scheduled sending.
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## What is a Draft?
 

--- a/fern/pages/core-concepts/inboxes.mdx
+++ b/fern/pages/core-concepts/inboxes.mdx
@@ -5,6 +5,8 @@ slug: inboxes
 description: Learn how AgentMail Inboxes act as scalable, API-first email accounts for your agents.
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## What is an Inbox?
 
 People are used to the traditional Gmail limitations -- only having one inbox. That's of the past.

--- a/fern/pages/core-concepts/inboxes.mdx
+++ b/fern/pages/core-concepts/inboxes.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Inboxes
 subtitle: The foundation of your agent's identity and communication.
 slug: inboxes
 description: Learn how AgentMail Inboxes act as scalable, API-first email accounts for your agents.
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## What is an Inbox?
 

--- a/fern/pages/core-concepts/labels.mdx
+++ b/fern/pages/core-concepts/labels.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Labels
 subtitle: Organizing and categorizing your agent's conversations at scale.
 slug: labels
 description: Learn how to use Labels to manage state, track campaigns, and filter messages for powerful agentic workflows.
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## What are `Labels`?
 

--- a/fern/pages/core-concepts/labels.mdx
+++ b/fern/pages/core-concepts/labels.mdx
@@ -5,6 +5,8 @@ slug: labels
 description: Learn how to use Labels to manage state, track campaigns, and filter messages for powerful agentic workflows.
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## What are `Labels`?
 
 `Labels` are simple, string-based tags that you can attach to your `Messages` and `Threads`. They are the primary mechanism for organizing, categorizing, and managing the state of your conversations, whether its automatically bucketing threads into specific categories for your outbound campaign, to segmenting warm leads for your outreach, to categorizing inbound into low-ticket, medium-ticket, high-ticket customers.

--- a/fern/pages/core-concepts/lists.mdx
+++ b/fern/pages/core-concepts/lists.mdx
@@ -5,6 +5,8 @@ slug: lists
 description: Learn how to use Lists to control which email addresses and domains your agents can send to or receive from.
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## What are Lists?
 
 `Lists` allow you to filter emails by allowing or blocking specific email addresses or domains. There are four list types based on two dimensions:

--- a/fern/pages/core-concepts/lists.mdx
+++ b/fern/pages/core-concepts/lists.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Lists
 subtitle: Filter emails by allowing or blocking specific addresses and domains.
 slug: lists
 description: Learn how to use Lists to control which email addresses and domains your agents can send to or receive from.
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## What are Lists?
 

--- a/fern/pages/core-concepts/messages.mdx
+++ b/fern/pages/core-concepts/messages.mdx
@@ -5,6 +5,8 @@ slug: messages
 description: Learn how to send, receive, and manage emails as Message objects with the AgentMail API.
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## What is a Message?
 
 In the AgentMail ecosystem, a `Message` is the API-first representation of a traditional email. It's a structured object containing all the elements you'd expect: a sender, recipients, a subject line, and the body of the email.

--- a/fern/pages/core-concepts/messages.mdx
+++ b/fern/pages/core-concepts/messages.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Messages
 subtitle: The fundamental unit of communication for your agents.
 slug: messages
 description: Learn how to send, receive, and manage emails as Message objects with the AgentMail API.
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## What is a Message?
 

--- a/fern/pages/core-concepts/pods.mdx
+++ b/fern/pages/core-concepts/pods.mdx
@@ -1,9 +1,9 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Pods
 description: Learn how to use pods for multi-tenant email management
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## What are Pods?
 

--- a/fern/pages/core-concepts/pods.mdx
+++ b/fern/pages/core-concepts/pods.mdx
@@ -3,6 +3,8 @@ title: Pods
 description: Learn how to use pods for multi-tenant email management
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## What are Pods?
 
 Pods are an isolated abstraction that sits between your **organization** and your **inboxes**, providing a method to segment and organize email infrastructure for multi-tenant applications. If you're building a service that offers email functionality to your customers, pods are your key to ensure customer resource isolation.

--- a/fern/pages/core-concepts/threads.mdx
+++ b/fern/pages/core-concepts/threads.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Threads
 subtitle: Organizing conversations across your Inboxes.
 slug: threads
 description: Learn how AgentMail Threads group messages into conversations and how to query them across your entire organization.
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## What is a Thread?
 

--- a/fern/pages/core-concepts/threads.mdx
+++ b/fern/pages/core-concepts/threads.mdx
@@ -5,6 +5,8 @@ slug: threads
 description: Learn how AgentMail Threads group messages into conversations and how to query them across your entire organization.
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## What is a Thread?
 
 A `Thread` is an API resource that represents a single conversation. It acts as a container, grouping a series of related `Messages` together in chronological order, just like a conversation thread in a traditional email client.

--- a/fern/pages/examples/auto-reply-agent.mdx
+++ b/fern/pages/examples/auto-reply-agent.mdx
@@ -3,6 +3,8 @@ title: "Auto-Reply Email Agent"
 description: "Build a simple agent that automatically responds to incoming emails with personalized messages"
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## Overview
 
 Learn how to build an email auto-reply agent that automatically responds to incoming emails. This beginner-friendly example demonstrates the core concepts of building with AgentMail: receiving webhooks, processing email events, and sending automated replies.

--- a/fern/pages/examples/auto-reply-agent.mdx
+++ b/fern/pages/examples/auto-reply-agent.mdx
@@ -1,9 +1,9 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "Auto-Reply Email Agent"
 description: "Build a simple agent that automatically responds to incoming emails with personalized messages"
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## Overview
 

--- a/fern/pages/examples/github-star-agent.mdx
+++ b/fern/pages/examples/github-star-agent.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "Example: Event-Driven Agent"
 subtitle: "Build a proactive, event-driven GitHub agent that uses Webhooks to handle replies in real time."
 slug: webhook-agent
 description: "A step-by-step guide to building a sophisticated agent that performs proactive outreach and uses webhooks for inbound message processing."
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 This tutorial walks you through building a sophisticated, dual-mode agent. It will:
 

--- a/fern/pages/examples/github-star-agent.mdx
+++ b/fern/pages/examples/github-star-agent.mdx
@@ -5,6 +5,8 @@ slug: webhook-agent
 description: "A step-by-step guide to building a sophisticated agent that performs proactive outreach and uses webhooks for inbound message processing."
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 This tutorial walks you through building a sophisticated, dual-mode agent. It will:
 
 1.  **Proactively monitor** a GitHub repository and send an outreach email when it detects a new "star".

--- a/fern/pages/examples/live-emails.mdx
+++ b/fern/pages/examples/live-emails.mdx
@@ -1,3 +1,5 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 # Live Email Agents
 
 We have several deployed agents running in production that demonstrate the power of AgentMail. These agents showcase different use cases and capabilities of our platform.

--- a/fern/pages/examples/newsletter-agent.mdx
+++ b/fern/pages/examples/newsletter-agent.mdx
@@ -1,0 +1,2 @@
+<Markdown src="/snippets/llms-index.mdx" />
+

--- a/fern/pages/examples/sales-agent-websocket.mdx
+++ b/fern/pages/examples/sales-agent-websocket.mdx
@@ -4,6 +4,8 @@ slug: sales-agent-websocket
 description: "A step-by-step guide to building an AI-powered sales agent that uses WebSocket for real-time email processing without polling or webhooks."
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## Overview
 
 Learn how to build a real-time sales agent that processes emails instantly using WebSocket connections. Unlike webhook-based agents that require ngrok and public URLs, this WebSocket approach connects directly to AgentMail for true real-time processing with minimal setup.

--- a/fern/pages/examples/sales-agent-websocket.mdx
+++ b/fern/pages/examples/sales-agent-websocket.mdx
@@ -1,10 +1,10 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "Sales Agent with WebSocket"
 slug: sales-agent-websocket
 description: "A step-by-step guide to building an AI-powered sales agent that uses WebSocket for real-time email processing without polling or webhooks."
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## Overview
 

--- a/fern/pages/examples/smart-labeling-agent.mdx
+++ b/fern/pages/examples/smart-labeling-agent.mdx
@@ -3,6 +3,8 @@ title: "Smart Email Labeling Agent"
 description: "Build an AI-powered agent that automatically classifies and labels incoming emails across multiple dimensions"
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## Overview
 
 Learn how to build an intelligent email classification agent that uses AI to automatically analyze and label incoming emails. This intermediate example showcases AgentMail's powerful labeling feature combined with OpenAI's GPT-4o-mini to create a sophisticated inbox automation system.

--- a/fern/pages/examples/smart-labeling-agent.mdx
+++ b/fern/pages/examples/smart-labeling-agent.mdx
@@ -1,9 +1,9 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "Smart Email Labeling Agent"
 description: "Build an AI-powered agent that automatically classifies and labels incoming emails across multiple dimensions"
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## Overview
 

--- a/fern/pages/examples/support-agent.mdx
+++ b/fern/pages/examples/support-agent.mdx
@@ -1,0 +1,2 @@
+<Markdown src="/snippets/llms-index.mdx" />
+

--- a/fern/pages/faq.mdx
+++ b/fern/pages/faq.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: FAQ
 subtitle: Frequently Asked Questions
 slug: faq
 description: Answers to common questions about AgentMail.
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 # Frequently Asked Questions
 

--- a/fern/pages/faq.mdx
+++ b/fern/pages/faq.mdx
@@ -5,6 +5,8 @@ slug: faq
 description: Answers to common questions about AgentMail.
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 # Frequently Asked Questions
 
 <AccordionGroup>

--- a/fern/pages/first-inbox.mdx
+++ b/fern/pages/first-inbox.mdx
@@ -1,0 +1,2 @@
+<Markdown src="/snippets/llms-index.mdx" />
+

--- a/fern/pages/get-started/introduction.mdx
+++ b/fern/pages/get-started/introduction.mdx
@@ -4,6 +4,8 @@ subtitle: Give AI agents email inboxes
 slug: introduction
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## What is AgentMail?
 
 AgentMail is an API platform for giving AI agents their own inboxes to send, receive, and act upon emails. We handle the infrastructure so you can focus on building email agents.

--- a/fern/pages/get-started/introduction.mdx
+++ b/fern/pages/get-started/introduction.mdx
@@ -1,10 +1,10 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Introduction
 subtitle: Give AI agents email inboxes
 slug: introduction
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## What is AgentMail?
 

--- a/fern/pages/get-started/quickstart.mdx
+++ b/fern/pages/get-started/quickstart.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Quickstart
 subtitle: Create your first inbox with the AgentMail API
 slug: quickstart
 description: Follow this guide to make your first AgentMail API request and create a new email inbox.
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## Quickest start
 

--- a/fern/pages/get-started/quickstart.mdx
+++ b/fern/pages/get-started/quickstart.mdx
@@ -5,6 +5,8 @@ slug: quickstart
 description: Follow this guide to make your first AgentMail API request and create a new email inbox.
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## Quickest start
 
 <CodeBlocks>

--- a/fern/pages/get-started/welcome.mdx
+++ b/fern/pages/get-started/welcome.mdx
@@ -1,10 +1,10 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Welcome
 slug: welcome
 description: Your starting point for building with the AgentMail API.
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 <Tip title="Welcome to AgentMail!" icon="fa-solid fa-star">
   We're thrilled to have you here! Dive in to learn how to give your AI agents their own email inboxes.

--- a/fern/pages/get-started/welcome.mdx
+++ b/fern/pages/get-started/welcome.mdx
@@ -4,6 +4,8 @@ slug: welcome
 description: Your starting point for building with the AgentMail API.
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 <Tip title="Welcome to AgentMail!" icon="fa-solid fa-star">
   We're thrilled to have you here! Dive in to learn how to give your AI agents their own email inboxes.
 </Tip>

--- a/fern/pages/get-started/what-is-agentmail.mdx
+++ b/fern/pages/get-started/what-is-agentmail.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: AgentMail Primer
 subtitle: Understanding AgentMail and Its Capabilities
 slug: primer
 description: An introduction to AgentMail, its features, use cases, market potential, and the team behind it.
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 # Introduction
 

--- a/fern/pages/get-started/what-is-agentmail.mdx
+++ b/fern/pages/get-started/what-is-agentmail.mdx
@@ -5,6 +5,8 @@ slug: primer
 description: An introduction to AgentMail, its features, use cases, market potential, and the team behind it.
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 # Introduction
 
 Today’s AI agents face challenges in orchestration, and identity and authentication.

--- a/fern/pages/guides/domains/custom-domains.mdx
+++ b/fern/pages/guides/domains/custom-domains.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Using Custom Domains
 subtitle: Strengthen your agent's identity and improve deliverability with your own domain.
 slug: custom-domains
 description: A step-by-step guide to configuring your custom domain with AgentMail for enhanced branding and trust.
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## Why Use a Custom Domain?
 

--- a/fern/pages/guides/domains/custom-domains.mdx
+++ b/fern/pages/guides/domains/custom-domains.mdx
@@ -5,6 +5,8 @@ slug: custom-domains
 description: A step-by-step guide to configuring your custom domain with AgentMail for enhanced branding and trust.
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## Why Use a Custom Domain?
 
 When you're deploying AI agents that send email at scale, deliverability and trust are paramount. While the default `@agentmail.to` domain is great for getting started, using your own custom domains is essential for production applications. It gives you control over your sending reputation and enables advanced strategies for high-volume outreach.

--- a/fern/pages/guides/domains/managing-domains.mdx
+++ b/fern/pages/guides/domains/managing-domains.mdx
@@ -5,6 +5,8 @@ slug: managing-domains
 description: Learn how to manage your custom domains effectively using AgentMail's API for enhanced deliverability and reputation management.
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## From Setup to Strategy
 
 You've successfully set up your first custom domain—now what?

--- a/fern/pages/guides/domains/managing-domains.mdx
+++ b/fern/pages/guides/domains/managing-domains.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Managing Your Domains
 subtitle: Best practices for monitoring, scaling, and optimizing your domain strategy for agent fleets.
 slug: managing-domains
 description: Learn how to manage your custom domains effectively using AgentMail's API for enhanced deliverability and reputation management.
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## From Setup to Strategy
 

--- a/fern/pages/guides/imap-smtp.mdx
+++ b/fern/pages/guides/imap-smtp.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "IMAP & SMTP"
 subtitle: "Connect to AgentMail with standard email protocols"
 slug: imap-smtp
 description: "Configure IMAP and SMTP to access your AgentMail inboxes using email clients or programmatic access."
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 AgentMail supports standard IMAP and SMTP protocols, allowing you to connect using traditional email clients or integrate with existing systems that rely on these protocols.
 

--- a/fern/pages/guides/imap-smtp.mdx
+++ b/fern/pages/guides/imap-smtp.mdx
@@ -5,6 +5,8 @@ slug: imap-smtp
 description: "Configure IMAP and SMTP to access your AgentMail inboxes using email clients or programmatic access."
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 AgentMail supports standard IMAP and SMTP protocols, allowing you to connect using traditional email clients or integrate with existing systems that rely on these protocols.
 
 ## What are IMAP and SMTP?

--- a/fern/pages/guides/integrate-livekit-agents.mdx
+++ b/fern/pages/guides/integrate-livekit-agents.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "Integrate LiveKit Agents"
 subtitle: "Build a voice assistant with real time email capabilities."
 slug: integrate-livekit-agents
 description: "A step-by-step guide to integrate with the LiveKit Agents SDK."
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## Overview
 

--- a/fern/pages/guides/integrate-livekit-agents.mdx
+++ b/fern/pages/guides/integrate-livekit-agents.mdx
@@ -5,6 +5,8 @@ slug: integrate-livekit-agents
 description: "A step-by-step guide to integrate with the LiveKit Agents SDK."
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## Overview
 
 This guide walks you through building a voice assistant with real time email capabilites. We use the LiveKit Agents SDK to build the voice functionality.

--- a/fern/pages/guides/sending-receiving-email.mdx
+++ b/fern/pages/guides/sending-receiving-email.mdx
@@ -5,6 +5,8 @@ slug: sending-receiving-email
 description: "A step-by-step guide to the practical workflow of sending initial emails and handling replies to have a full conversation."
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 This guide walks you through the complete, practical workflow of an agent having a conversation. While the `Core Concepts` pages detail the individual API calls, this guide shows you how to stitch them together to create a functional conversational loop.
 
 ## The Foundation: Sending HTML & Text

--- a/fern/pages/guides/sending-receiving-email.mdx
+++ b/fern/pages/guides/sending-receiving-email.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "Guide: Sending & Receiving Email"
 subtitle: "Building your first conversational agent workflow."
 slug: sending-receiving-email
 description: "A step-by-step guide to the practical workflow of sending initial emails and handling replies to have a full conversation."
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 This guide walks you through the complete, practical workflow of an agent having a conversation. While the `Core Concepts` pages detail the individual API calls, this guide shows you how to stitch them together to create a functional conversational loop.
 

--- a/fern/pages/handling-attachments.mdx
+++ b/fern/pages/handling-attachments.mdx
@@ -1,0 +1,2 @@
+<Markdown src="/snippets/llms-index.mdx" />
+

--- a/fern/pages/integrations/crewai.mdx
+++ b/fern/pages/integrations/crewai.mdx
@@ -4,3 +4,5 @@ subtitle: CrewAI integration
 slug: integrations/crewai
 description: AgentMail's CrewAI integration
 ---
+
+<Markdown src="/snippets/llms-index.mdx" />

--- a/fern/pages/integrations/crewai.mdx
+++ b/fern/pages/integrations/crewai.mdx
@@ -1,8 +1,8 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: CrewAI
 subtitle: CrewAI integration
 slug: integrations/crewai
 description: AgentMail's CrewAI integration
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />

--- a/fern/pages/integrations/mastra.mdx
+++ b/fern/pages/integrations/mastra.mdx
@@ -4,3 +4,5 @@ subtitle: Mastra integration
 slug: integrations/mastra
 description: AgentMail's Mastra integration
 ---
+
+<Markdown src="/snippets/llms-index.mdx" />

--- a/fern/pages/integrations/mastra.mdx
+++ b/fern/pages/integrations/mastra.mdx
@@ -1,8 +1,8 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Mastra
 subtitle: Mastra integration
 slug: integrations/mastra
 description: AgentMail's Mastra integration
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />

--- a/fern/pages/integrations/mcp.mdx
+++ b/fern/pages/integrations/mcp.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: MCP
 subtitle: Connect AgentMail to any MCP-compatible AI client
 slug: integrations/mcp
 description: AgentMail's Model Context Protocol (MCP) integration
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## Getting started
 

--- a/fern/pages/integrations/mcp.mdx
+++ b/fern/pages/integrations/mcp.mdx
@@ -5,6 +5,8 @@ slug: integrations/mcp
 description: AgentMail's Model Context Protocol (MCP) integration
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## Getting started
 
 The Model Context Protocol (MCP) is an open standard that enables AI applications to connect with external tools and data sources. AgentMail provides an MCP server that allows any MCP-compatible client to interact with the AgentMail API.

--- a/fern/pages/integrations/moltbot.mdx
+++ b/fern/pages/integrations/moltbot.mdx
@@ -5,6 +5,8 @@ slug: integrations/moltbot
 description: AgentMail's Moltbot (Clawdbot) integration
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## Getting started
 
 Moltbot (formerly Clawdbot) is an open-source AI personal assistant that runs on your own devices and integrates with messaging platforms like WhatsApp, Telegram, Discord, and Slack. By adding AgentMail to Moltbot, your agent gains the ability to send and receive emails, enabling two-way email conversations alongside your existing chat channels.

--- a/fern/pages/integrations/moltbot.mdx
+++ b/fern/pages/integrations/moltbot.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Moltbot
 subtitle: Give your Moltbot agent its own email inbox
 slug: integrations/moltbot
 description: AgentMail's Moltbot (Clawdbot) integration
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## Getting started
 

--- a/fern/pages/integrations/openclaw.mdx
+++ b/fern/pages/integrations/openclaw.mdx
@@ -5,6 +5,8 @@ slug: integrations/openclaw
 description: AgentMail's Openclaw integration
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## Getting started
 
 Openclaw (formerly Moltbot) is an open-source AI personal assistant that runs on your own devices and integrates with messaging platforms like WhatsApp, Telegram, Discord, and Slack. By adding AgentMail to Openclaw, your agent gains the ability to send and receive emails, enabling two-way email conversations alongside your existing chat channels.

--- a/fern/pages/integrations/openclaw.mdx
+++ b/fern/pages/integrations/openclaw.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Openclaw
 subtitle: Give your Openclaw agent its own email inbox
 slug: integrations/openclaw
 description: AgentMail's Openclaw integration
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## Getting started
 

--- a/fern/pages/integrations/overview.mdx
+++ b/fern/pages/integrations/overview.mdx
@@ -5,6 +5,8 @@ slug: integrations/overview
 description: Overview of AgentMail's integrations
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## Platforms
 
 <CardGroup>

--- a/fern/pages/integrations/overview.mdx
+++ b/fern/pages/integrations/overview.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Integrations
 subtitle: Overview of AgentMail's integrations
 slug: integrations/overview
 description: Overview of AgentMail's integrations
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## Platforms
 

--- a/fern/pages/integrations/replit.mdx
+++ b/fern/pages/integrations/replit.mdx
@@ -5,6 +5,8 @@ slug: integrations/replit
 description: AgentMail's Replit integration
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## Getting started
 
 Replit is a cloud-based app and agent builder with a built in IDE, AI assistant, and deployment infrastructure.

--- a/fern/pages/integrations/replit.mdx
+++ b/fern/pages/integrations/replit.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Replit
 subtitle: Integrate AgentMail with your Replit apps and agents
 slug: integrations/replit
 description: AgentMail's Replit integration
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## Getting started
 

--- a/fern/pages/integrations/skills.mdx
+++ b/fern/pages/integrations/skills.mdx
@@ -5,6 +5,8 @@ slug: integrations/skills
 description: AgentMail's official skill for Moltbot, Claude Code, Cursor, and other AI assistants
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## Getting started
 
 AgentMail provides an official skill that can be installed on AI coding assistants and agents that support the [AgentSkills](https://skills.sh) format. This includes Moltbot, Claude Code, Cursor, Codex, and other compatible tools.

--- a/fern/pages/integrations/skills.mdx
+++ b/fern/pages/integrations/skills.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Skills
 subtitle: Add AgentMail to AI coding assistants with the official skill
 slug: integrations/skills
 description: AgentMail's official skill for Moltbot, Claude Code, Cursor, and other AI assistants
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## Getting started
 

--- a/fern/pages/integrations/smithery.mdx
+++ b/fern/pages/integrations/smithery.mdx
@@ -1,8 +1,8 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Smithery
 subtitle: Replit integration
 slug: integrations/smithery
 description: AgentMail's Smithery integration
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />

--- a/fern/pages/integrations/smithery.mdx
+++ b/fern/pages/integrations/smithery.mdx
@@ -4,3 +4,5 @@ subtitle: Replit integration
 slug: integrations/smithery
 description: AgentMail's Smithery integration
 ---
+
+<Markdown src="/snippets/llms-index.mdx" />

--- a/fern/pages/integrations/x402.mdx
+++ b/fern/pages/integrations/x402.mdx
@@ -5,6 +5,8 @@ slug: integrations/x402
 description: AgentMail's x402 integration for HTTP-native payments
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## Getting started
 
 [x402](https://www.x402.org/) is an open payment protocol that enables HTTP-native payments. By integrating x402 with AgentMail, your agents can pay for API usage directly over HTTP without managing API keys or subscriptions.

--- a/fern/pages/integrations/x402.mdx
+++ b/fern/pages/integrations/x402.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: x402
 subtitle: Pay-per-use AgentMail with the x402 payment protocol
 slug: integrations/x402
 description: AgentMail's x402 integration for HTTP-native payments
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## Getting started
 

--- a/fern/pages/news-agent.mdx
+++ b/fern/pages/news-agent.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Newsletter Agent
 subtitle: Creating an agent that monitors incoming emails and sends most relevant emails to user
 slug: newsletter-agent
 description: An introduction to AgentMail, its features, use cases, market potential, and the team behind it.
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ### Creating a Newsletter Agent with AgentMail
 

--- a/fern/pages/news-agent.mdx
+++ b/fern/pages/news-agent.mdx
@@ -5,6 +5,8 @@ slug: newsletter-agent
 description: An introduction to AgentMail, its features, use cases, market potential, and the team behind it.
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ### Creating a Newsletter Agent with AgentMail
 
 This is an example implementation of how Agent's can be equipped with their own inbox and interact with internet resources autonomously, and do the heavy duty lifting of tedious tasks.

--- a/fern/pages/recieving-emails.mdx
+++ b/fern/pages/recieving-emails.mdx
@@ -1,0 +1,2 @@
+<Markdown src="/snippets/llms-index.mdx" />
+

--- a/fern/pages/resources/community.mdx
+++ b/fern/pages/resources/community.mdx
@@ -1,10 +1,10 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "Join the AgentMail Community"
 slug: community
 description: "Connect with the AgentMail team and developers, share what you're building, and get support."
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 <CardGroup>
   <Card

--- a/fern/pages/resources/community.mdx
+++ b/fern/pages/resources/community.mdx
@@ -4,6 +4,8 @@ slug: community
 description: "Connect with the AgentMail team and developers, share what you're building, and get support."
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 <CardGroup>
   <Card
     title="Join our Discord Server"

--- a/fern/pages/resources/faq.mdx
+++ b/fern/pages/resources/faq.mdx
@@ -1,10 +1,10 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "Frequently Asked Questions (FAQ)"
 slug: faq
 description: "Find answers to common questions about AgentMail, from core concepts to best practices and security."
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 <AccordionGroup>
   <Accordion title="What is AgentMail?">

--- a/fern/pages/resources/faq.mdx
+++ b/fern/pages/resources/faq.mdx
@@ -4,6 +4,8 @@ slug: faq
 description: "Find answers to common questions about AgentMail, from core concepts to best practices and security."
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 <AccordionGroup>
   <Accordion title="What is AgentMail?">
     AgentMail is an API-first email platform designed specifically for building

--- a/fern/pages/resources/security/email-protocols.mdx
+++ b/fern/pages/resources/security/email-protocols.mdx
@@ -4,6 +4,8 @@ slug: email-protocols
 description: "Learn why we ask for DNS records and what SPF, DKIM, and DMARC are."
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 When you add a custom domain to AgentMail, we ask you to add several records to your DNS settings. We understand that this can seem daunting, and we want to be completely transparent about what these records are and why they are necessary.
 
 In short, by adding these records, you are giving AgentMail **permission** to do two things:

--- a/fern/pages/resources/security/email-protocols.mdx
+++ b/fern/pages/resources/security/email-protocols.mdx
@@ -1,10 +1,10 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "Understanding Email Authentication (SPF, DKIM, DMARC)"
 slug: email-protocols
 description: "Learn why we ask for DNS records and what SPF, DKIM, and DMARC are."
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 When you add a custom domain to AgentMail, we ask you to add several records to your DNS settings. We understand that this can seem daunting, and we want to be completely transparent about what these records are and why they are necessary.
 

--- a/fern/pages/resources/security/soc2.mdx
+++ b/fern/pages/resources/security/soc2.mdx
@@ -5,6 +5,8 @@ sidebar_position: 40
 lastUpdated: "2025-11-02"
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 > AgentMail has **achieved SOC 2 Type I compliance** (July 2025) and is currently working toward **Type II certification** (target: Q1 2026).
 
 ---

--- a/fern/pages/resources/security/soc2.mdx
+++ b/fern/pages/resources/security/soc2.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "SOC 2 Compliance"
 description: "AgentMail's SOC 2 Type I achievement and Type II certification progress."
 sidebar_position: 40
 lastUpdated: "2025-11-02"
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 > AgentMail has **achieved SOC 2 Type I compliance** (July 2025) and is currently working toward **Type II certification** (target: Q1 2026).
 

--- a/fern/pages/resources/security/spam-virus-detection.mdx
+++ b/fern/pages/resources/security/spam-virus-detection.mdx
@@ -1,10 +1,10 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "Spam & Virus Detection"
 slug: spam-virus-detection
 description: "How AgentMail automatically scans incoming emails for spam and viruses."
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 AgentMail automatically scans every inbound message for spam and viruses before it reaches your inbox. This happens transparently — there is nothing you need to configure.
 

--- a/fern/pages/resources/security/spam-virus-detection.mdx
+++ b/fern/pages/resources/security/spam-virus-detection.mdx
@@ -4,6 +4,8 @@ slug: spam-virus-detection
 description: "How AgentMail automatically scans incoming emails for spam and viruses."
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 AgentMail automatically scans every inbound message for spam and viruses before it reaches your inbox. This happens transparently — there is nothing you need to configure.
 
 ## Virus Detection

--- a/fern/pages/resources/support.mdx
+++ b/fern/pages/resources/support.mdx
@@ -1,8 +1,10 @@
----
+ ---
 title: Support
 slug: support
 description: Get help with AgentMail through our support channels.
 ---
+
+<Markdown src="/snippets/llms-index.mdx" />
 
 ## Need Help?
 

--- a/fern/pages/resources/support.mdx
+++ b/fern/pages/resources/support.mdx
@@ -1,10 +1,10 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
  ---
 title: Support
 slug: support
 description: Get help with AgentMail through our support channels.
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## Need Help?
 

--- a/fern/pages/resources/talon.mdx
+++ b/fern/pages/resources/talon.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "Email Reply Extraction with Talon"
 subtitle: "Extract clean reply content from email threads using Talon library"
 slug: talon-reply-extraction
 description: "Learn how to use Talon to extract new content from email replies, removing quoted text with 93.8% accuracy."
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ## Why Talon?
 

--- a/fern/pages/resources/talon.mdx
+++ b/fern/pages/resources/talon.mdx
@@ -5,6 +5,8 @@ slug: talon-reply-extraction
 description: "Learn how to use Talon to extract new content from email replies, removing quoted text with 93.8% accuracy."
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ## Why Talon?
 
 Email threads accumulate quoted replies that clutter the actual content. When processing emails programmatically, you need just the new message, not the entire conversation history.

--- a/fern/pages/sending-emails.mdx
+++ b/fern/pages/sending-emails.mdx
@@ -1,0 +1,2 @@
+<Markdown src="/snippets/llms-index.mdx" />
+

--- a/fern/pages/substack-agent.mdx
+++ b/fern/pages/substack-agent.mdx
@@ -5,6 +5,8 @@ slug: substack-agent
 description: An introduction to AgentMail, its features, use cases, market potential, and the team behind it.
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 <iframe
   width="100%"
   height="500"

--- a/fern/pages/substack-agent.mdx
+++ b/fern/pages/substack-agent.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Substack Agent Demo
 subtitle: Creating an agent that monitors incoming emails sends most relevant Substack content to user
 slug: substack-agent
 description: An introduction to AgentMail, its features, use cases, market potential, and the team behind it.
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 <iframe
   width="100%"

--- a/fern/pages/use-cases.mdx
+++ b/fern/pages/use-cases.mdx
@@ -1,0 +1,2 @@
+<Markdown src="/snippets/llms-index.mdx" />
+

--- a/fern/pages/using-agents.mdx
+++ b/fern/pages/using-agents.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: Agent Application
 subtitle: Creating Agents that can send and receive emails
 slug: using-agents
 description: An introduction to AgentMail, its features, use cases, market potential, and the team behind it.
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ### Using Agents with AgentMail
 

--- a/fern/pages/using-agents.mdx
+++ b/fern/pages/using-agents.mdx
@@ -5,6 +5,8 @@ slug: using-agents
 description: An introduction to AgentMail, its features, use cases, market potential, and the team behind it.
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ### Using Agents with AgentMail
 
 AgentMail can be easily integrated with LangChain to create AI agents that can send, receive, and manage emails. This guide will walk you through creating an agent with access to AgentMail via tools.

--- a/fern/pages/webhooks.mdx
+++ b/fern/pages/webhooks.mdx
@@ -1,0 +1,2 @@
+<Markdown src="/snippets/llms-index.mdx" />
+

--- a/fern/pages/webhooks/webhook-setup.mdx
+++ b/fern/pages/webhooks/webhook-setup.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "Webhook Setup Guide"
 subtitle: "Step-by-step guide to configure webhooks."
 slug: webhook-setup
 description: "A comprehensive guide to setting up webhooks with ngrok and AgentMail, including account creation, inbox setup, and code examples."
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 This guide walks you through the complete process of setting up webhooks to receive real-time notifications from AgentMail. You'll learn how to create an ngrok account, set up an inbox, configure webhooks, and write a simple webhook receiver.
 

--- a/fern/pages/webhooks/webhook-setup.mdx
+++ b/fern/pages/webhooks/webhook-setup.mdx
@@ -5,6 +5,8 @@ slug: webhook-setup
 description: "A comprehensive guide to setting up webhooks with ngrok and AgentMail, including account creation, inbox setup, and code examples."
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 This guide walks you through the complete process of setting up webhooks to receive real-time notifications from AgentMail. You'll learn how to create an ngrok account, set up an inbox, configure webhooks, and write a simple webhook receiver.
 
 ## Prerequisites

--- a/fern/pages/webhooks/webhook-verification.mdx
+++ b/fern/pages/webhooks/webhook-verification.mdx
@@ -5,6 +5,8 @@ slug: webhook-verification
 description: "Learn how to verify webhook signatures to secure your webhook endpoints and prevent spoofed requests."
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 When building webhook receivers, it's critical to verify that incoming requests actually originate from AgentMail and haven't been tampered with. AgentMail uses [Svix](https://www.svix.com/) to deliver webhooks, which provides cryptographic signature verification.
 
 ## Why Verify Webhooks?

--- a/fern/pages/webhooks/webhook-verification.mdx
+++ b/fern/pages/webhooks/webhook-verification.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "Verifying Webhooks"
 subtitle: "Ensure webhook requests are authentically from AgentMail."
 slug: webhook-verification
 description: "Learn how to verify webhook signatures to secure your webhook endpoints and prevent spoofed requests."
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 When building webhook receivers, it's critical to verify that incoming requests actually originate from AgentMail and haven't been tampered with. AgentMail uses [Svix](https://www.svix.com/) to deliver webhooks, which provides cryptographic signature verification.
 

--- a/fern/pages/webhooks/webhooks-events.mdx
+++ b/fern/pages/webhooks/webhooks-events.mdx
@@ -3,6 +3,8 @@ title: "Webhook Events"
 slug: events
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 As mentioned in the overview, webhooks allow us to create event-driven applications.
 
 AgentMail supports multiple event types that allow you to build comprehensive, event-driven workflows for your email agents.

--- a/fern/pages/webhooks/webhooks-events.mdx
+++ b/fern/pages/webhooks/webhooks-events.mdx
@@ -1,9 +1,9 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "Webhook Events"
 slug: events
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 As mentioned in the overview, webhooks allow us to create event-driven applications.
 

--- a/fern/pages/webhooks/webhooks-overview.mdx
+++ b/fern/pages/webhooks/webhooks-overview.mdx
@@ -5,6 +5,8 @@ slug: overview
 description: "Learn how to use Webhooks to build responsive, event-driven email agents with AgentMail."
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 Webhooks are the best way to get real-time information about what's happening with your emails. Instead of constantly asking the AgentMail API if there's a new email (a process called polling), you can register a URL, and we will send you a `POST` request with the details as soon as an event happens.
 
 This event-driven approach is more efficient and allows you to build fast, responsive agents that can react instantly to incoming messages.

--- a/fern/pages/webhooks/webhooks-overview.mdx
+++ b/fern/pages/webhooks/webhooks-overview.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "Webhooks Overview"
 subtitle: "Get real-time notifications for email events."
 slug: overview
 description: "Learn how to use Webhooks to build responsive, event-driven email agents with AgentMail."
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 Webhooks are the best way to get real-time information about what's happening with your emails. Instead of constantly asking the AgentMail API if there's a new email (a process called polling), you can register a URL, and we will send you a `POST` request with the details as soon as an event happens.
 

--- a/fern/pages/websockets-quickstart.mdx
+++ b/fern/pages/websockets-quickstart.mdx
@@ -4,6 +4,8 @@ subtitle: "Get started with real-time email event streaming"
 slug: websockets/quickstart
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 ```typescript title="TypeScript"
 import { AgentMailClient } from "agentmail";
 

--- a/fern/pages/websockets-quickstart.mdx
+++ b/fern/pages/websockets-quickstart.mdx
@@ -1,10 +1,10 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "WebSockets Quickstart"
 subtitle: "Get started with real-time email event streaming"
 slug: websockets/quickstart
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 ```typescript title="TypeScript"
 import { AgentMailClient } from "agentmail";

--- a/fern/pages/websockets.mdx
+++ b/fern/pages/websockets.mdx
@@ -5,6 +5,8 @@ slug: websockets
 description: "Learn how to use WebSockets for instant email notifications without webhooks or polling."
 ---
 
+<Markdown src="/snippets/llms-index.mdx" />
+
 WebSockets provide a persistent, bidirectional connection to AgentMail for receiving email events in real-time. Unlike webhooks, WebSockets don't require a public URL or external tools like ngrok.
 
 ## Why Use WebSockets?

--- a/fern/pages/websockets.mdx
+++ b/fern/pages/websockets.mdx
@@ -1,11 +1,11 @@
+<Markdown src="/snippets/llms-index.mdx" />
+
 ---
 title: "WebSockets"
 subtitle: "Real-time, low-latency email event streaming"
 slug: websockets
 description: "Learn how to use WebSockets for instant email notifications without webhooks or polling."
 ---
-
-<Markdown src="/snippets/llms-index.mdx" />
 
 WebSockets provide a persistent, bidirectional connection to AgentMail for receiving email events in real-time. Unlike webhooks, WebSockets don't require a public URL or external tools like ngrok.
 

--- a/fern/snippets/llms-index.mdx
+++ b/fern/snippets/llms-index.mdx
@@ -1,5 +1,5 @@
 <llms-only>
 > ## Documentation Index
-> Fetch the complete documentation index at: https://docs.agentmail.to/llms.txt
+> Fetch the complete documentation index at: `https://docs.agentmail.to/llms.txt`
 > Use this file to discover all available pages before exploring further.
 </llms-only>

--- a/fern/snippets/llms-index.mdx
+++ b/fern/snippets/llms-index.mdx
@@ -1,0 +1,5 @@
+<llms-only>
+> ## Documentation Index
+> Fetch the complete documentation index at: https://docs.agentmail.to/llms.txt
+> Use this file to discover all available pages before exploring further.
+</llms-only>


### PR DESCRIPTION
Testing whether llm header will be shown on the doc's markdown file. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hidden, LLM-only documentation index pointer at the top of all docs pages to improve indexing and navigation for language models. Aligns with ENG-321.

- **New Features**
  - Added fern/snippets/llms-index.mdx with a pointer to https://docs.agentmail.to/llms.txt inside an llms-only block; updated the copy for clarity.
  - Injected the snippet as the first element on every docs page via <Markdown src="/snippets/llms-index.mdx" />, and updated fern.config.json version to 4.2.2.

<sup>Written for commit ed172a81b0f21641decdc998a40cc0ab16ebcdfe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

