### PR TITLE
Add and reoder routes

### DIFF
--- a/fern/definition/domains.yml
+++ b/fern/definition/domains.yml
@@ -106,6 +106,10 @@ types:
       domain: DomainName
       feedback_enabled: FeedbackEnabled
 
+  UpdateDomainRequest:
+    properties:
+      feedback_enabled: optional<FeedbackEnabled>
+
 service:
   url: Http
   base-path: /domains
@@ -152,6 +156,17 @@ service:
       response: Domain
       errors:
         - global.ValidationError
+
+    update:
+      method: PATCH
+      path: /{domain_id}
+      display-name: Update Domain
+      path-parameters:
+        domain_id: DomainId
+      request: UpdateDomainRequest
+      response: Domain
+      errors:
+        - global.NotFoundError
 
     delete:
       method: DELETE

--- a/fern/definition/inboxes/drafts.yml
+++ b/fern/definition/inboxes/drafts.yml
@@ -73,6 +73,15 @@ service:
       errors:
         - global.NotFoundError
 
+    delete:
+      method: DELETE
+      path: /{draft_id}
+      display-name: Delete Draft
+      path-parameters:
+        draft_id: drafts.DraftId
+      errors:
+        - global.NotFoundError
+
     send:
       method: POST
       path: /{draft_id}/send
@@ -85,12 +94,3 @@ service:
         - global.NotFoundError
         - global.ValidationError
         - messages.MessageRejectedError
-
-    delete:
-      method: DELETE
-      path: /{draft_id}
-      display-name: Delete Draft
-      path-parameters:
-        draft_id: drafts.DraftId
-      errors:
-        - global.NotFoundError

--- a/fern/definition/inboxes/messages.yml
+++ b/fern/definition/inboxes/messages.yml
@@ -65,6 +65,18 @@ service:
       errors:
         - global.NotFoundError
 
+    update:
+      method: PATCH
+      path: /{message_id}
+      display-name: Update Message
+      path-parameters:
+        message_id: messages.MessageId
+      request: messages.UpdateMessageRequest
+      response: messages.Message
+      errors:
+        - global.ValidationError
+        - global.NotFoundError
+
     send:
       method: POST
       path: /send
@@ -114,15 +126,3 @@ service:
         - global.ValidationError
         - global.NotFoundError
         - messages.MessageRejectedError
-
-    update:
-      method: PATCH
-      path: /{message_id}
-      display-name: Update Message
-      path-parameters:
-        message_id: messages.MessageId
-      request: messages.UpdateMessageRequest
-      response: messages.Message
-      errors:
-        - global.ValidationError
-        - global.NotFoundError

--- a/fern/definition/lists.yml
+++ b/fern/definition/lists.yml
@@ -87,15 +87,6 @@ service:
   auth: true
 
   endpoints:
-    create:
-      method: POST
-      path: ""
-      display-name: Create List Entry
-      request: CreateListEntryRequest
-      response: ListEntry
-      errors:
-        - global.ValidationError
-
     list:
       method: GET
       path: ""
@@ -118,6 +109,15 @@ service:
       response: ListEntry
       errors:
         - global.NotFoundError
+
+    create:
+      method: POST
+      path: ""
+      display-name: Create List Entry
+      request: CreateListEntryRequest
+      response: ListEntry
+      errors:
+        - global.ValidationError
 
     delete:
       method: DELETE

--- a/fern/definition/pods/__package__.yml
+++ b/fern/definition/pods/__package__.yml
@@ -1,12 +1,12 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
 
 navigation:
+  - api-keys.yml
+  - domains.yml
   - inboxes.yml
   - threads.yml
   - drafts.yml
-  - domains.yml
   - lists.yml
-  - api-keys.yml
   - metrics.yml
 
 imports:

--- a/fern/definition/pods/api-keys.yml
+++ b/fern/definition/pods/api-keys.yml
@@ -13,16 +13,6 @@ service:
   auth: true
 
   endpoints:
-    create:
-      method: POST
-      path: ""
-      display-name: Create API Key
-      request: api-keys.CreateApiKeyRequest
-      response: api-keys.CreateApiKeyResponse
-      errors:
-        - global.NotFoundError
-        - global.ValidationError
-
     list:
       method: GET
       path: ""
@@ -35,6 +25,16 @@ service:
       response: api-keys.ListApiKeysResponse
       errors:
         - global.NotFoundError
+
+    create:
+      method: POST
+      path: ""
+      display-name: Create API Key
+      request: api-keys.CreateApiKeyRequest
+      response: api-keys.CreateApiKeyResponse
+      errors:
+        - global.NotFoundError
+        - global.ValidationError
 
     delete:
       method: DELETE

--- a/fern/definition/pods/domains.yml
+++ b/fern/definition/pods/domains.yml
@@ -27,15 +27,6 @@ service:
       errors:
         - global.NotFoundError
 
-    create:
-      method: POST
-      path: ""
-      display-name: Create Domain
-      request: domains.CreateDomainRequest
-      response: domains.Domain
-      errors:
-        - global.ValidationError
-
     get:
       method: GET
       path: /{domain_id}
@@ -46,10 +37,49 @@ service:
       errors:
         - global.NotFoundError
 
+    getZoneFile:
+      method: GET
+      path: /{domain_id}/zone-file
+      display-name: Get Zone File
+      path-parameters:
+        domain_id: domains.DomainId
+      response: file
+      errors:
+        - global.NotFoundError
+
+    create:
+      method: POST
+      path: ""
+      display-name: Create Domain
+      request: domains.CreateDomainRequest
+      response: domains.Domain
+      errors:
+        - global.ValidationError
+
+    update:
+      method: PATCH
+      path: /{domain_id}
+      display-name: Update Domain
+      path-parameters:
+        domain_id: domains.DomainId
+      request: domains.UpdateDomainRequest
+      response: domains.Domain
+      errors:
+        - global.NotFoundError
+
     delete:
       method: DELETE
       path: /{domain_id}
       display-name: Delete Domain
+      path-parameters:
+        domain_id: domains.DomainId
+      errors:
+        - global.NotFoundError
+
+    verify:
+      method: POST
+      path: /{domain_id}/verify
+      display-name: Verify Domain
       path-parameters:
         domain_id: domains.DomainId
       errors:

--- a/fern/definition/pods/inboxes.yml
+++ b/fern/definition/pods/inboxes.yml
@@ -46,6 +46,17 @@ service:
       errors:
         - global.ValidationError
 
+    update:
+      method: PATCH
+      path: /{inbox_id}
+      display-name: Update Inbox
+      path-parameters:
+        inbox_id: inboxes.InboxId
+      request: inboxes.UpdateInboxRequest
+      response: inboxes.Inbox
+      errors:
+        - global.NotFoundError
+
     delete:
       method: DELETE
       path: /{inbox_id}

--- a/fern/definition/pods/lists.yml
+++ b/fern/definition/pods/lists.yml
@@ -15,15 +15,6 @@ service:
   auth: true
 
   endpoints:
-    create:
-      method: POST
-      path: ""
-      display-name: Create List Entry
-      request: lists.CreateListEntryRequest
-      response: lists.PodListEntry
-      errors:
-        - global.ValidationError
-
     list:
       method: GET
       path: ""
@@ -46,6 +37,15 @@ service:
       response: lists.PodListEntry
       errors:
         - global.NotFoundError
+
+    create:
+      method: POST
+      path: ""
+      display-name: Create List Entry
+      request: lists.CreateListEntryRequest
+      response: lists.PodListEntry
+      errors:
+        - global.ValidationError
 
     delete:
       method: DELETE

--- a/fern/definition/pods/threads.yml
+++ b/fern/definition/pods/threads.yml
@@ -54,3 +54,19 @@ service:
       response: attachments.AttachmentResponse
       errors:
         - global.NotFoundError
+
+    delete:
+      method: DELETE
+      path: /{thread_id}
+      display-name: Delete Thread
+      docs: Moves the thread to trash by adding a trash label to all messages. If the thread is already in trash, it will be permanently deleted. Use `permanent=true` to force permanent deletion.
+      path-parameters:
+        thread_id: threads.ThreadId
+      request:
+        name: DeleteThreadRequest
+        query-parameters:
+          permanent:
+            type: optional<boolean>
+            docs: If true, permanently delete the thread instead of moving to trash.
+      errors:
+        - global.NotFoundError

--- a/fern/definition/threads.yml
+++ b/fern/definition/threads.yml
@@ -163,3 +163,19 @@ service:
       response: attachments.AttachmentResponse
       errors:
         - global.NotFoundError
+
+    delete:
+      method: DELETE
+      path: /{thread_id}
+      display-name: Delete Thread
+      docs: Moves the thread to trash by adding a trash label to all messages. If the thread is already in trash, it will be permanently deleted. Use `permanent=true` to force permanent deletion.
+      path-parameters:
+        thread_id: ThreadId
+      request:
+        name: DeleteThreadRequest
+        query-parameters:
+          permanent:
+            type: optional<boolean>
+            docs: If true, permanently delete the thread instead of moving to trash.
+      errors:
+        - global.NotFoundError

--- a/fern/definition/webhooks/__package__.yml
+++ b/fern/definition/webhooks/__package__.yml
@@ -98,6 +98,15 @@ service:
       errors:
         - global.NotFoundError
 
+    create:
+      method: POST
+      path: ""
+      display-name: Create Webhook
+      request: CreateWebhookRequest
+      response: Webhook
+      errors:
+        - global.ValidationError
+
     update:
       method: PATCH
       path: /{webhook_id}
@@ -108,15 +117,6 @@ service:
       response: Webhook
       errors:
         - global.NotFoundError
-        - global.ValidationError
-
-    create:
-      method: POST
-      path: ""
-      display-name: Create Webhook
-      request: CreateWebhookRequest
-      response: Webhook
-      errors:
         - global.ValidationError
 
     delete:

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -394,16 +394,16 @@ navigation:
           python: agentmail
           typescript: agentmail
         layout:
+          - organizations
+          - pods
+          - api-keys
+          - domains
           - inboxes
           - threads
           - messages
           - drafts
-          - domains
-          - lists
           - webhooks
           - websockets
+          - lists
           - metrics
-          - api-keys
-          - pods
-          - organizations
   - tab: changelog


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds missing domain, inbox, and thread routes and reorders endpoint and docs navigation to match product behavior and improve clarity. Aligns with Linear ENG-348.

- **New Features**
  - Domains: PATCH /domains/{domain_id} (UpdateDomainRequest), POST /domains/{domain_id}/verify, GET /domains/{domain_id}/zone-file.
  - Inboxes: PATCH /inboxes/{inbox_id}.
  - Threads: DELETE /threads/{thread_id}?permanent=boolean.

- **Refactors**
  - Reordered endpoints to group read-before-write (e.g., moved create/delete/update to follow list/get where appropriate) across lists, webhooks, messages, drafts, and API keys.
  - Updated `pods` and main docs navigation to a clearer order (organizations → pods → api-keys → domains → inboxes → threads → messages → drafts → webhooks → websockets → lists → metrics).

<sup>Written for commit 17b23ca6766bd01f643ac749fd53e4ab01847cc5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

