### PR TITLE
[ENG-347] Small Edit

### DIFF
--- a/fern/definition/messages.yml
+++ b/fern/definition/messages.yml
@@ -146,7 +146,7 @@ types:
         docs: Ordered by `timestamp` descending.
 
   RawMessageResponse:
-    docs: Signed URL to download the raw .eml file. Uses CloudFront signing, same as attachments.
+    docs: S3 presigned URL to download the raw .eml file.
     properties:
       message_id:
         type: MessageId
@@ -156,7 +156,7 @@ types:
         docs: Size of the raw message in bytes.
       download_url:
         type: string
-        docs: Pre-signed CloudFront URL to download the raw message. Expires at expires_at.
+        docs: S3 presigned URL to download the raw message. Expires at expires_at.
       expires_at:
         type: datetime
         docs: Time at which the download URL expires.

--- a/fern/pages/core-concepts/messages.mdx
+++ b/fern/pages/core-concepts/messages.mdx
@@ -235,7 +235,7 @@ Copy one of the blocks below into Cursor or Claude for complete Messages API kno
    * - messages.forward(inboxId, messageId, { to, subject?, text?, html? })
    * - messages.update(inboxId, messageId, { addLabels?, removeLabels? })
    * - messages.getAttachment(inboxId, messageId, attachmentId)
-   * - messages.getRaw(inboxId, messageId) -> { message_id, size, download_url, expires_at } (CloudFront signed URL for .eml)
+   * - messages.getRaw(inboxId, messageId) -> { message_id, size, download_url, expires_at } (S3 presigned URL for .eml)
    * - messages.getRaw(inboxId, messageId)
    *
    * Reply content: use extractedText/extractedHtml for new content without quoted history.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified that `download_url` from `messages.getRaw` (`RawMessageResponse`) is an S3 presigned URL, not a CloudFront signed URL. Updates the API schema and core concepts docs to align with ENG-347.

<sup>Written for commit e777a33385e3715537e5f5cf3f5dc1c7c3e67fe6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

