### PR TITLE
add recipant limit

### DIFF
--- a/fern/pages/core-concepts/messages.mdx
+++ b/fern/pages/core-concepts/messages.mdx
@@ -81,6 +81,10 @@ console.log(`Message sent successfully with ID: ${sentMessage.id}`);
 
 </CodeBlocks>
 
+<Warning>
+  **Recipient limit:** Each send or reply supports a maximum of **50 recipients** across the combined total of `to`, `cc`, and `bcc`. If you exceed this limit, the API will return an error.
+</Warning>
+
 ### 3. List `Messages` in an `Inbox`
 
 You can retrieve a list of all `Messages` within a specific `Inbox`. This is useful for getting a history of all correspondence.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Documented a 50-recipient limit for sending or replying to messages, counted across the combined total of to, cc, and bcc. Added a warning callout in the Messages core concepts page; the API returns an error if the limit is exceeded.

<sup>Written for commit 7315e65643bc981ed446469e4b0b20e5472b3bf5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

