### PR TITLE
update on skills

### DIFF
--- a/fern/pages/integrations/skills.mdx
+++ b/fern/pages/integrations/skills.mdx
@@ -13,34 +13,24 @@ The skill is available at [skills.sh/agentmail-to/agentmail-skills/agentmail](ht
 
 ## Installation
 
-### OpenClaw
-
-Install the skill using the OpenClaw CLI:
+Install the skill using the [skills CLI](https://github.com/vercel-labs/skills). This works with Claude Code, Cursor, OpenClaw, Codex, and other compatible agents:
 
 ```bash
-openclaw skills install agentmail-to/agentmail-skills/agentmail
+npx skills add agentmail-to/agentmail-skills
 ```
 
-Or install via ClawHub:
+To skip interactive prompts, specify the skill and agent directly:
+
+```bash
+npx skills add agentmail-to/agentmail-skills --skill agentmail --agent claude-code
+```
+
+### OpenClaw via ClawHub
+
+OpenClaw users can also install via ClawHub:
 
 ```bash
 npx clawhub@latest install agentmail
-```
-
-### Claude Code
-
-Add the skill to your Claude Code configuration:
-
-```bash
-claude-code skills install agentmail-to/agentmail-skills/agentmail
-```
-
-### Cursor
-
-Install the skill in Cursor:
-
-```bash
-cursor skills install agentmail-to/agentmail-skills/agentmail
 ```
 
 ### Manual installation


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized the installation docs to use the `skills` CLI across agents (Claude Code, Cursor, OpenClaw, Codex) for a simpler, single flow. Removed per-agent commands, added a non-interactive example, and kept an OpenClaw option via `clawhub`.

<sup>Written for commit cf90b6a664a359734590b3fedf62a2450afe972f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

