### PR TITLE
ENG-374: Update add_labels and remove_labels to accept string or array

### DIFF
--- a/fern/definition/messages.yml
+++ b/fern/definition/messages.yml
@@ -235,14 +235,21 @@ types:
       attachments: optional<SendMessageAttachments>
       headers: optional<SendMessageHeaders>
 
+  UpdateMessageLabels:
+    discriminated: false
+    union:
+      - string
+      - list<string>
+    docs: Label or list of labels.
+
   UpdateMessageRequest:
     properties:
       add_labels:
-        type: optional<list<string>>
-        docs: Labels to add to message.
+        type: optional<UpdateMessageLabels>
+        docs: Label or labels to add to message.
       remove_labels:
-        type: optional<list<string>>
-        docs: Labels to remove from message.
+        type: optional<UpdateMessageLabels>
+        docs: Label or labels to remove from message.
 
 errors:
   MessageRejectedError:


### PR DESCRIPTION
`add_labels` and `remove_labels` in `UpdateMessageRequest` now accept either a single string or a list of strings, matching the API change merged in agentmail-to/agentmail-api.

Added `UpdateMessageLabels` union type (following the existing `Addresses` pattern) and updated both fields to use it.