### PR TITLE
small change

### DIFF
--- a/.github/workflows/sync-stainless.yml
+++ b/.github/workflows/sync-stainless.yml
@@ -21,6 +21,7 @@ jobs:
         run: npm install -g fern-api
 
       - name: Generate OpenAPI spec
+        working-directory: fern
         run: fern generate --group openapi --local
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
@@ -30,7 +31,7 @@ jobs:
           SPEC_FILE=$(find openapi -name "openapi.*" -type f | head -1)
           jq -Rs '{project: "agentmail", branch: "main", revision: {"openapi.json": {content: .}}}' \
             "$SPEC_FILE" > /tmp/stainless-body.json
-          curl -sf -X POST "https://api.stainless.com/v0/builds" \
+          curl -sS --fail-with-body -X POST "https://api.stainless.com/v0/builds" \
             -H "Authorization: Bearer $STAINLESS_API_KEY" \
             -H "Content-Type: application/json" \
             -d @/tmp/stainless-body.json


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the Stainless sync workflow by running OpenAPI generation from the `fern` folder and improving error reporting when uploading builds.

- **Bug Fixes**
  - Set working-directory to `fern` for the OpenAPI generation step to use the correct config and paths.
  - Switch to `curl -sS --fail-with-body` for the Stainless API request to surface error bodies and fail on HTTP errors.

<sup>Written for commit 689ce42cf9c9e3e3eae8510c531c9f74bdf2a171. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

