### PR TITLE
Add google adk

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -261,6 +261,9 @@ navigation:
           - page: CLI
             icon: fa-solid fa-terminal
             path: pages/integrations/cli.mdx
+          - page: Google ADK
+            icon: fa-brands fa-google
+            path: pages/integrations/google-adk.mdx
           - page: OpenClaw
             icon: fa-solid fa-robot
             path: pages/integrations/openclaw.mdx

--- a/fern/pages/integrations/google-adk.mdx
+++ b/fern/pages/integrations/google-adk.mdx
@@ -1,0 +1,134 @@
+---
+title: Google ADK
+subtitle: Give your Google ADK agent its own email inbox
+slug: integrations/google-adk
+description: AgentMail's Google Agent Development Kit (ADK) integration
+---
+
+## Getting started
+
+[Google Agent Development Kit (ADK)](https://google.github.io/adk-docs/) is an open-source framework for building AI agents. By connecting AgentMail to your ADK agent via the [AgentMail MCP server](https://github.com/agentmail-to/agentmail-mcp), your agent can create inboxes, send and receive emails, manage threads, and handle attachments using natural language.
+
+## Use cases
+
+- **Give agents their own inboxes:** Create dedicated email addresses for your agents so they can send and receive emails independently, just like a human team member.
+- **Automate email workflows:** Let your agent handle email conversations end to end, including sending initial outreach, reading replies, and following up on threads.
+- **Manage conversations across inboxes:** List and search across threads and messages, forward emails, and retrieve attachments to keep your agent informed and responsive.
+
+## Prerequisites
+
+1. An [AgentMail account](https://agentmail.to/) with an API key from the [AgentMail Console](https://console.agentmail.to)
+2. [Google ADK](https://google.github.io/adk-docs/get-started/) installed (`pip install google-adk` or `npm install @google/adk`)
+
+## Setup
+
+ADK supports AgentMail through the MCP tool interface. You can connect the AgentMail MCP server using either a local stdio transport or a remote SSE transport.
+
+<Tabs>
+  <Tab title="Python">
+
+### Local MCP server
+
+```python
+from google.adk.agents import Agent
+from google.adk.tools.mcp_tool import McpToolset
+from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
+from mcp import StdioServerParameters
+
+AGENTMAIL_API_KEY = "YOUR_AGENTMAIL_API_KEY"
+
+root_agent = Agent(
+    model="gemini-2.5-pro",
+    name="agentmail_agent",
+    instruction="Help users manage email inboxes and send messages",
+    tools=[
+        McpToolset(
+            connection_params=StdioConnectionParams(
+                server_params=StdioServerParameters(
+                    command="npx",
+                    args=[
+                        "-y",
+                        "agentmail-mcp",
+                    ],
+                    env={
+                        "AGENTMAIL_API_KEY": AGENTMAIL_API_KEY,
+                    }
+                ),
+                timeout=30,
+            ),
+        )
+    ],
+)
+```
+
+  </Tab>
+  <Tab title="TypeScript">
+
+### Local MCP server
+
+```typescript
+import { LlmAgent, MCPToolset } from "@google/adk";
+
+const AGENTMAIL_API_KEY = "YOUR_AGENTMAIL_API_KEY";
+
+const rootAgent = new LlmAgent({
+    model: "gemini-2.5-pro",
+    name: "agentmail_agent",
+    instruction: "Help users manage email inboxes and send messages",
+    tools: [
+        new MCPToolset({
+            type: "StdioConnectionParams",
+            serverParams: {
+                command: "npx",
+                args: ["-y", "agentmail-mcp"],
+                env: {
+                    AGENTMAIL_API_KEY: AGENTMAIL_API_KEY,
+                },
+            },
+        }),
+    ],
+});
+
+export { rootAgent };
+```
+
+  </Tab>
+</Tabs>
+
+## Available tools
+
+Once connected, your ADK agent has access to the following AgentMail tools:
+
+### Inbox management
+
+| Tool | Description |
+| --- | --- |
+| `list_inboxes` | List all inboxes |
+| `get_inbox` | Get details for a specific inbox |
+| `create_inbox` | Create a new inbox with a username and domain |
+| `delete_inbox` | Delete an inbox |
+
+### Thread management
+
+| Tool | Description |
+| --- | --- |
+| `list_threads` | List threads in an inbox |
+| `get_thread` | Get a specific thread with its messages |
+| `get_attachment` | Download an attachment from a message |
+
+### Message operations
+
+| Tool | Description |
+| --- | --- |
+| `send_message` | Send a new email from an inbox |
+| `reply_to_message` | Reply to an existing message |
+| `forward_message` | Forward a message to another recipient |
+| `update_message` | Update message properties such as read status |
+
+## Resources
+
+- [AgentMail MCP Server](https://github.com/agentmail-to/agentmail-mcp)
+- [Google ADK Documentation](https://google.github.io/adk-docs/)
+- [ADK AgentMail Integration Page](https://google.github.io/adk-docs/integrations/agentmail/)
+- [Google Cloud Livestream featuring AgentMail](https://www.youtube.com/live/nId1rrAIEx4)
+- [AgentMail API Reference](/api-reference)

--- a/fern/pages/integrations/google-adk.mdx
+++ b/fern/pages/integrations/google-adk.mdx
@@ -7,7 +7,7 @@ description: AgentMail's Google Agent Development Kit (ADK) integration
 
 ## Getting started
 
-[Google Agent Development Kit (ADK)](https://google.github.io/adk-docs/) is an open-source framework for building AI agents. By connecting AgentMail to your ADK agent via the [AgentMail MCP server](https://github.com/agentmail-to/agentmail-mcp), your agent can create inboxes, send and receive emails, manage threads, and handle attachments using natural language.
+[Google Agent Development Kit (ADK)](https://google.github.io/adk-docs/) is an open-source framework for building AI agents. By connecting AgentMail to your ADK agent via the [AgentMail MCP server](https://github.com/agentmail-to/agentmail-smithery-mcp), your agent can create inboxes, send and receive emails, manage threads, and handle attachments using natural language.
 
 ## Use cases
 
@@ -22,78 +22,67 @@ description: AgentMail's Google Agent Development Kit (ADK) integration
 
 ## Setup
 
-ADK supports AgentMail through the MCP tool interface. You can connect the AgentMail MCP server using either a local stdio transport or a remote SSE transport.
+ADK supports AgentMail through the MCP tool interface. Connect the AgentMail MCP server as a local stdio transport:
 
-<Tabs>
-  <Tab title="Python">
+<CodeBlocks>
+  ```python title="Python"
+  from google.adk.agents import Agent
+  from google.adk.tools.mcp_tool import McpToolset
+  from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
+  from mcp import StdioServerParameters
 
-### Local MCP server
+  AGENTMAIL_API_KEY = "YOUR_AGENTMAIL_API_KEY"
 
-```python
-from google.adk.agents import Agent
-from google.adk.tools.mcp_tool import McpToolset
-from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
-from mcp import StdioServerParameters
+  root_agent = Agent(
+      model="gemini-2.5-pro",
+      name="agentmail_agent",
+      instruction="Help users manage email inboxes and send messages",
+      tools=[
+          McpToolset(
+              connection_params=StdioConnectionParams(
+                  server_params=StdioServerParameters(
+                      command="npx",
+                      args=[
+                          "-y",
+                          "agentmail-mcp",
+                      ],
+                      env={
+                          "AGENTMAIL_API_KEY": AGENTMAIL_API_KEY,
+                      }
+                  ),
+                  timeout=30,
+              ),
+          )
+      ],
+  )
+  ```
 
-AGENTMAIL_API_KEY = "YOUR_AGENTMAIL_API_KEY"
+  ```typescript title="TypeScript"
+  import { LlmAgent, MCPToolset } from "@google/adk";
 
-root_agent = Agent(
-    model="gemini-2.5-pro",
-    name="agentmail_agent",
-    instruction="Help users manage email inboxes and send messages",
-    tools=[
-        McpToolset(
-            connection_params=StdioConnectionParams(
-                server_params=StdioServerParameters(
-                    command="npx",
-                    args=[
-                        "-y",
-                        "agentmail-mcp",
-                    ],
-                    env={
-                        "AGENTMAIL_API_KEY": AGENTMAIL_API_KEY,
-                    }
-                ),
-                timeout=30,
-            ),
-        )
-    ],
-)
-```
+  const AGENTMAIL_API_KEY = "YOUR_AGENTMAIL_API_KEY";
 
-  </Tab>
-  <Tab title="TypeScript">
+  const rootAgent = new LlmAgent({
+      model: "gemini-2.5-pro",
+      name: "agentmail_agent",
+      instruction: "Help users manage email inboxes and send messages",
+      tools: [
+          new MCPToolset({
+              type: "StdioConnectionParams",
+              serverParams: {
+                  command: "npx",
+                  args: ["-y", "agentmail-mcp"],
+                  env: {
+                      AGENTMAIL_API_KEY: AGENTMAIL_API_KEY,
+                  },
+              },
+          }),
+      ],
+  });
 
-### Local MCP server
-
-```typescript
-import { LlmAgent, MCPToolset } from "@google/adk";
-
-const AGENTMAIL_API_KEY = "YOUR_AGENTMAIL_API_KEY";
-
-const rootAgent = new LlmAgent({
-    model: "gemini-2.5-pro",
-    name: "agentmail_agent",
-    instruction: "Help users manage email inboxes and send messages",
-    tools: [
-        new MCPToolset({
-            type: "StdioConnectionParams",
-            serverParams: {
-                command: "npx",
-                args: ["-y", "agentmail-mcp"],
-                env: {
-                    AGENTMAIL_API_KEY: AGENTMAIL_API_KEY,
-                },
-            },
-        }),
-    ],
-});
-
-export { rootAgent };
-```
-
-  </Tab>
-</Tabs>
+  export { rootAgent };
+  ```
+</CodeBlocks>
 
 ## Available tools
 
@@ -124,11 +113,3 @@ Once connected, your ADK agent has access to the following AgentMail tools:
 | `reply_to_message` | Reply to an existing message |
 | `forward_message` | Forward a message to another recipient |
 | `update_message` | Update message properties such as read status |
-
-## Resources
-
-- [AgentMail MCP Server](https://github.com/agentmail-to/agentmail-mcp)
-- [Google ADK Documentation](https://google.github.io/adk-docs/)
-- [ADK AgentMail Integration Page](https://google.github.io/adk-docs/integrations/agentmail/)
-- [Google Cloud Livestream featuring AgentMail](https://www.youtube.com/live/nId1rrAIEx4)
-- [AgentMail API Reference](/api-reference)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new Google ADK integration doc that shows how to connect AgentMail via the MCP server so ADK agents can manage inboxes and email threads. Adds the page to the Integrations navigation and removes a duplicate from earlier commits.

- **New Features**
  - Added `pages/integrations/google-adk.mdx` with Python and TypeScript setup (stdio via `npx agentmail-mcp`), tool reference, prerequisites, and resources (mentions `@google/adk`).
  - Updated `fern/docs.yml` to include “Google ADK” in the Integrations sidebar with a Google icon.

- **Bug Fixes**
  - Removed a duplicate introduced earlier in the integration changes.

<sup>Written for commit 7d9fb9fe242fd72c5a3d8d2e3b565483c2ec5bb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

