### PR TITLE
update threads docs

### DIFF
--- a/fern/definition/__package__.yml
+++ b/fern/definition/__package__.yml
@@ -77,3 +77,7 @@ errors:
   NotFoundError:
     status-code: 404
     type: ErrorResponse
+
+  UnprocessableError:
+    status-code: 422
+    type: ErrorResponse

--- a/fern/definition/inboxes/messages.yml
+++ b/fern/definition/inboxes/messages.yml
@@ -72,7 +72,7 @@ service:
       path-parameters:
         message_id: messages.MessageId
       request: messages.UpdateMessageRequest
-      response: messages.Message
+      response: messages.UpdateMessageResponse
       errors:
         - global.ValidationError
         - global.NotFoundError

--- a/fern/definition/inboxes/threads.yml
+++ b/fern/definition/inboxes/threads.yml
@@ -55,6 +55,20 @@ service:
       errors:
         - global.NotFoundError
 
+    update:
+      method: PATCH
+      path: /{thread_id}
+      display-name: Update Thread
+      docs: Updates thread labels. Cannot add or remove system labels (sent, received, bounced, etc.). Rejects requests with a `422` for threads with 100 or more messages.
+      path-parameters:
+        thread_id: threads.ThreadId
+      request: threads.UpdateThreadRequest
+      response: threads.UpdateThreadResponse
+      errors:
+        - global.ValidationError
+        - global.NotFoundError
+        - global.UnprocessableError
+
     delete:
       method: DELETE
       path: /{thread_id}

--- a/fern/definition/messages.yml
+++ b/fern/definition/messages.yml
@@ -209,6 +209,11 @@ types:
       message_id: MessageId
       thread_id: threads.ThreadId
 
+  UpdateMessageResponse:
+    properties:
+      message_id: MessageId
+      labels: MessageLabels
+
   ReplyAll:
     type: boolean
     docs: Reply to all recipients of the original message.

--- a/fern/definition/pods/threads.yml
+++ b/fern/definition/pods/threads.yml
@@ -55,6 +55,20 @@ service:
       errors:
         - global.NotFoundError
 
+    update:
+      method: PATCH
+      path: /{thread_id}
+      display-name: Update Thread
+      docs: Updates thread labels. Cannot add or remove system labels (sent, received, bounced, etc.). Rejects requests with a `422` for threads with 100 or more messages.
+      path-parameters:
+        thread_id: threads.ThreadId
+      request: threads.UpdateThreadRequest
+      response: threads.UpdateThreadResponse
+      errors:
+        - global.ValidationError
+        - global.NotFoundError
+        - global.UnprocessableError
+
     delete:
       method: DELETE
       path: /{thread_id}

--- a/fern/definition/threads.yml
+++ b/fern/definition/threads.yml
@@ -108,6 +108,20 @@ types:
         type: list<messages.Message>
         docs: Messages in thread. Ordered by `timestamp` ascending.
 
+  UpdateThreadRequest:
+    properties:
+      add_labels:
+        type: optional<list<string>>
+        docs: Labels to add to thread. Cannot be system labels.
+      remove_labels:
+        type: optional<list<string>>
+        docs: Labels to remove from thread. Cannot be system labels. Takes priority over `add_labels` (in the event of duplicate labels passed in).
+
+  UpdateThreadResponse:
+    properties:
+      thread_id: ThreadId
+      labels: ThreadLabels
+
   ListThreadsResponse:
     properties:
       count: global.Count
@@ -163,6 +177,20 @@ service:
       response: attachments.AttachmentResponse
       errors:
         - global.NotFoundError
+
+    update:
+      method: PATCH
+      path: /{thread_id}
+      display-name: Update Thread
+      docs: Updates thread labels. Cannot add or remove system labels (sent, received, bounced, etc.). Rejects requests with a `422` for threads with 100 or more messages.
+      path-parameters:
+        thread_id: ThreadId
+      request: UpdateThreadRequest
+      response: UpdateThreadResponse
+      errors:
+        - global.ValidationError
+        - global.NotFoundError
+        - global.UnprocessableError
 
     delete:
       method: DELETE


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Update Thread APIs to manage thread labels across `threads`, `inboxes/threads`, and `pods/threads`. Also introduces a typed message update response and a global 422 error for oversized threads.

- **New Features**
  - Added PATCH /{thread_id} Update Thread to `threads`, `inboxes/threads`, and `pods/threads`.
  - Introduced `UpdateThreadRequest` (add_labels, remove_labels; remove wins; system labels blocked) and `UpdateThreadResponse` (thread_id, labels).
  - Added global `UnprocessableError` (422) when a thread has 100+ messages; also returns validation and not found errors.
  - Message update now returns `UpdateMessageResponse` (message_id, labels); updated `inboxes/messages.update` to use it.

<sup>Written for commit 70f95d644560b80947198633f5f3f17121ea7f9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

