### PR TITLE
feat: host docs at agentmail.to/docs with canonical URLs

### DIFF
--- a/fern/custom.js
+++ b/fern/custom.js
@@ -1,3 +1,27 @@
+// Canonical URL: point both instances to agentmail.to/docs/...
+// docs.agentmail.to/quickstart → canonical: agentmail.to/docs/quickstart
+// agentmail.to/docs/quickstart → canonical: agentmail.to/docs/quickstart (already correct)
+(function () {
+  var link = document.querySelector('link[rel="canonical"]');
+  var host = window.location.hostname;
+  var path = window.location.pathname;
+
+  var canonicalPath = host === "docs.agentmail.to"
+    ? "/docs" + path  // prepend /docs for subdomain
+    : path;           // subpath instance already has /docs
+
+  var canonicalUrl = "https://agentmail.to" + canonicalPath;
+
+  if (link) {
+    link.href = canonicalUrl;
+  } else {
+    link = document.createElement("link");
+    link.rel = "canonical";
+    link.href = canonicalUrl;
+    document.head.appendChild(link);
+  }
+})();
+
 // Reo.dev tracking script
 !(function () {
   var e, t, n;

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -18,9 +18,6 @@ instances:
         repo: agentmail-docs
         branch: main
 
-metadata:
-  canonical-host: https://agentmail.to
-
 title: AgentMail | Documentation
 favicon: assets/agentmail-favicon.ico
 

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -10,6 +10,16 @@ instances:
         owner: agentmail-to
         repo: agentmail-docs
         branch: main
+  - url: https://agentmail-subpath.docs.buildwithfern.com
+    custom-domain: agentmail.to/docs
+    edit-this-page:
+      github:
+        owner: agentmail-to
+        repo: agentmail-docs
+        branch: main
+
+metadata:
+  canonical-host: https://agentmail.to
 
 title: AgentMail | Documentation
 favicon: assets/agentmail-favicon.ico


### PR DESCRIPTION
## Summary

Adds a second Fern docs instance so documentation is served at both `docs.agentmail.to` and `agentmail.to/docs`, with proper canonical URLs pointing to the subpath.

## Changes

- **New instance** in `docs.yml`: `agentmail-subpath.docs.buildwithfern.com` with custom domain `agentmail.to/docs`
- **Canonical URLs via `custom.js`**: Dynamically sets `<link rel="canonical">` on both instances to point to `agentmail.to/docs/...`
  - `docs.agentmail.to/quickstart` → canonical: `agentmail.to/docs/quickstart`
  - `agentmail.to/docs/quickstart` → canonical: `agentmail.to/docs/quickstart` (already correct)
- **No changes** to the existing `docs.agentmail.to` instance — it continues to work as before

### Why JS instead of `canonical-host`?

Fern's `canonical-host` only swaps the hostname without adjusting the path. This breaks the subdomain instance — `docs.agentmail.to/quickstart` would get a canonical of `agentmail.to/quickstart` (landing page) instead of `agentmail.to/docs/quickstart`. The JS approach handles the path prefix correctly for both instances.

## Deployment Notes

1. Merge this PR and run `fern generate --docs --instance agentmail-subpath.docs.buildwithfern.com` to publish the new instance
2. The companion PR on `agentmail-web` adds a Vercel rewrite to proxy `/docs` traffic to the new Fern instance
3. Both PRs should be deployed together for the subpath to work end-to-end

---
*Automated via pr-create*