### PR TITLE
docs: add CLI examples across all documentation and API reference

### DIFF
--- a/fern/definition/agent.yml
+++ b/fern/definition/agent.yml
@@ -57,6 +57,11 @@ service:
         This endpoint is idempotent. Calling it again with the same `human_email` will rotate the API key and resend the OTP if expired.
 
         The returned API key has limited permissions until the organization is verified via the verify endpoint.
+
+        **CLI:**
+        ```bash
+        agentmail agent sign-up --human-email user@example.com --username my-agent
+        ```
       request: AgentSignupRequest
       response: AgentSignupResponse
       errors:
@@ -73,5 +78,10 @@ service:
         On success, the organization is upgraded from `agent_unverified` to `agent_verified`, the send allowlist is removed, and free plan entitlements are applied.
 
         The OTP expires after 24 hours and allows a maximum of 10 attempts.
+
+        **CLI:**
+        ```bash
+        agentmail agent verify --otp-code 123456
+        ```
       request: AgentVerifyRequest
       response: AgentVerifyResponse

--- a/fern/definition/api-keys.yml
+++ b/fern/definition/api-keys.yml
@@ -186,6 +186,11 @@ service:
       method: GET
       path: ""
       display-name: List API Keys
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail api-keys list
+        ```
       request:
         name: ListApiKeysRequest
         query-parameters:
@@ -198,6 +203,11 @@ service:
       method: POST
       path: ""
       display-name: Create API Key
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail api-keys create --name "My Key"
+        ```
       request: CreateApiKeyRequest
       response: CreateApiKeyResponse
       errors:
@@ -207,6 +217,11 @@ service:
       method: DELETE
       path: /{api_key_id}
       display-name: Delete API Key
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail api-keys delete --api-key-id <api_key_id>
+        ```
       path-parameters:
         api_key_id: ApiKeyId
       errors:

--- a/fern/definition/domains.yml
+++ b/fern/definition/domains.yml
@@ -125,6 +125,11 @@ service:
       method: GET
       path: ""
       display-name: List Domains
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail domains list
+        ```
       request:
         name: ListDomainsRequest
         query-parameters:
@@ -137,6 +142,11 @@ service:
       method: GET
       path: /{domain_id}
       display-name: Get Domain
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail domains retrieve --domain-id <domain_id>
+        ```
       path-parameters:
         domain_id: DomainId
       response: Domain
@@ -147,6 +157,11 @@ service:
       method: GET
       path: /{domain_id}/zone-file
       display-name: Get Zone File
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail domains get-zone-file --domain-id <domain_id>
+        ```
       path-parameters:
         domain_id: DomainId
       response: file
@@ -157,6 +172,11 @@ service:
       method: POST
       path: ""
       display-name: Create Domain
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail domains create --domain example.com
+        ```
       request: CreateDomainRequest
       response: Domain
       errors:
@@ -166,6 +186,11 @@ service:
       method: PATCH
       path: /{domain_id}
       display-name: Update Domain
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail domains update --domain-id <domain_id>
+        ```
       path-parameters:
         domain_id: DomainId
       request: UpdateDomainRequest
@@ -177,6 +202,11 @@ service:
       method: DELETE
       path: /{domain_id}
       display-name: Delete Domain
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail domains delete --domain-id <domain_id>
+        ```
       path-parameters:
         domain_id: DomainId
       errors:
@@ -186,6 +216,11 @@ service:
       method: POST
       path: /{domain_id}/verify
       display-name: Verify Domain
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail domains verify --domain-id <domain_id>
+        ```
       path-parameters:
         domain_id: DomainId
       errors:

--- a/fern/definition/drafts.yml
+++ b/fern/definition/drafts.yml
@@ -164,6 +164,11 @@ service:
       method: GET
       path: ""
       display-name: List Drafts
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail drafts list
+        ```
       request:
         name: ListDraftsRequest
         query-parameters:
@@ -181,6 +186,11 @@ service:
       method: GET
       path: /{draft_id}
       display-name: Get Draft
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail drafts retrieve --draft-id <draft_id>
+        ```
       path-parameters:
         draft_id: DraftId
       response: Draft
@@ -191,6 +201,11 @@ service:
       method: GET
       path: /{draft_id}/attachments/{attachment_id}
       display-name: Get Attachment
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail drafts get-attachment --draft-id <draft_id> --attachment-id <attachment_id>
+        ```
       path-parameters:
         draft_id: DraftId
         attachment_id: attachments.AttachmentId

--- a/fern/definition/inboxes/__package__.yml
+++ b/fern/definition/inboxes/__package__.yml
@@ -77,6 +77,11 @@ service:
       method: GET
       path: ""
       display-name: List Inboxes
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes list
+        ```
       request:
         name: ListInboxesRequest
         query-parameters:
@@ -89,6 +94,11 @@ service:
       method: GET
       path: /{inbox_id}
       display-name: Get Inbox
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes retrieve --inbox-id <inbox_id>
+        ```
       path-parameters:
         inbox_id: InboxId
       response: Inbox
@@ -99,6 +109,11 @@ service:
       method: POST
       path: ""
       display-name: Create Inbox
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes create --display-name "My Agent" --username myagent --domain agentmail.to
+        ```
       request: optional<CreateInboxRequest>
       response: Inbox
       errors:
@@ -108,6 +123,11 @@ service:
       method: PATCH
       path: /{inbox_id}
       display-name: Update Inbox
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes update --inbox-id <inbox_id> --display-name "Updated Name"
+        ```
       path-parameters:
         inbox_id: InboxId
       request: UpdateInboxRequest
@@ -119,6 +139,11 @@ service:
       method: DELETE
       path: /{inbox_id}
       display-name: Delete Inbox
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes delete --inbox-id <inbox_id>
+        ```
       path-parameters:
         inbox_id: InboxId
       errors:

--- a/fern/definition/inboxes/api-keys.yml
+++ b/fern/definition/inboxes/api-keys.yml
@@ -17,6 +17,11 @@ service:
       method: GET
       path: ""
       display-name: List API Keys
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:api-keys list --inbox-id <inbox_id>
+        ```
       request:
         name: ListApiKeysRequest
         query-parameters:
@@ -30,6 +35,11 @@ service:
       method: POST
       path: ""
       display-name: Create API Key
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:api-keys create --inbox-id <inbox_id> --name "My Key"
+        ```
       request: api-keys.CreateApiKeyRequest
       response: api-keys.CreateApiKeyResponse
       errors:
@@ -40,6 +50,11 @@ service:
       method: DELETE
       path: /{api_key_id}
       display-name: Delete API Key
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:api-keys delete --inbox-id <inbox_id> --api-key-id <api_key_id>
+        ```
       path-parameters:
         api_key_id: api-keys.ApiKeyId
       errors:

--- a/fern/definition/inboxes/drafts.yml
+++ b/fern/definition/inboxes/drafts.yml
@@ -19,6 +19,11 @@ service:
       method: GET
       path: ""
       display-name: List Drafts
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:drafts list --inbox-id <inbox_id>
+        ```
       request:
         name: ListDraftsRequest
         query-parameters:
@@ -36,6 +41,11 @@ service:
       method: GET
       path: /{draft_id}
       display-name: Get Draft
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:drafts retrieve --inbox-id <inbox_id> --draft-id <draft_id>
+        ```
       path-parameters:
         draft_id: drafts.DraftId
       response: drafts.Draft
@@ -46,6 +56,11 @@ service:
       method: GET
       path: /{draft_id}/attachments/{attachment_id}
       display-name: Get Attachment
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:drafts get-attachment --inbox-id <inbox_id> --draft-id <draft_id> --attachment-id <attachment_id>
+        ```
       path-parameters:
         draft_id: drafts.DraftId
         attachment_id: attachments.AttachmentId
@@ -57,6 +72,11 @@ service:
       method: POST
       path: ""
       display-name: Create Draft
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:drafts create --inbox-id <inbox_id> --to recipient@example.com --subject "Draft subject" --text "Draft body"
+        ```
       request: drafts.CreateDraftRequest
       response: drafts.Draft
       errors:
@@ -66,6 +86,11 @@ service:
       method: PATCH
       path: /{draft_id}
       display-name: Update Draft
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:drafts update --inbox-id <inbox_id> --draft-id <draft_id> --subject "Updated subject"
+        ```
       path-parameters:
         draft_id: drafts.DraftId
       request: drafts.UpdateDraftRequest
@@ -77,6 +102,11 @@ service:
       method: DELETE
       path: /{draft_id}
       display-name: Delete Draft
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:drafts delete --inbox-id <inbox_id> --draft-id <draft_id>
+        ```
       path-parameters:
         draft_id: drafts.DraftId
       errors:
@@ -86,6 +116,11 @@ service:
       method: POST
       path: /{draft_id}/send
       display-name: Send Draft
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:drafts send --inbox-id <inbox_id> --draft-id <draft_id>
+        ```
       path-parameters:
         draft_id: drafts.DraftId
       request: messages.UpdateMessageRequest

--- a/fern/definition/inboxes/lists.yml
+++ b/fern/definition/inboxes/lists.yml
@@ -19,6 +19,11 @@ service:
       method: GET
       path: ""
       display-name: List Entries
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:lists list --inbox-id <inbox_id> --direction <direction> --type <type>
+        ```
       request:
         name: InboxListListEntriesRequest
         query-parameters:
@@ -30,6 +35,11 @@ service:
       method: GET
       path: /{entry}
       display-name: Get List Entry
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:lists retrieve --inbox-id <inbox_id> --direction <direction> --type <type> --entry <entry>
+        ```
       path-parameters:
         entry:
           type: string
@@ -42,6 +52,11 @@ service:
       method: POST
       path: ""
       display-name: Create List Entry
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:lists create --inbox-id <inbox_id> --direction <direction> --type <type> --entry user@example.com
+        ```
       request: lists.CreateListEntryRequest
       response: lists.PodListEntry
       errors:
@@ -51,6 +66,11 @@ service:
       method: DELETE
       path: /{entry}
       display-name: Delete List Entry
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:lists delete --inbox-id <inbox_id> --direction <direction> --type <type> --entry <entry>
+        ```
       path-parameters:
         entry:
           type: string

--- a/fern/definition/inboxes/messages.yml
+++ b/fern/definition/inboxes/messages.yml
@@ -18,6 +18,11 @@ service:
       method: GET
       path: ""
       display-name: List Messages
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:messages list --inbox-id <inbox_id>
+        ```
       request:
         name: ListMessagesRequest
         query-parameters:
@@ -38,6 +43,11 @@ service:
       method: GET
       path: /{message_id}
       display-name: Get Message
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:messages retrieve --inbox-id <inbox_id> --message-id <message_id>
+        ```
       path-parameters:
         message_id: messages.MessageId
       response: messages.Message
@@ -48,6 +58,11 @@ service:
       method: GET
       path: /{message_id}/attachments/{attachment_id}
       display-name: Get Attachment
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:messages get-attachment --inbox-id <inbox_id> --message-id <message_id> --attachment-id <attachment_id>
+        ```
       path-parameters:
         message_id: messages.MessageId
         attachment_id: attachments.AttachmentId
@@ -59,6 +74,11 @@ service:
       method: GET
       path: /{message_id}/raw
       display-name: Get Raw Message
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:messages get-raw --inbox-id <inbox_id> --message-id <message_id>
+        ```
       path-parameters:
         message_id: messages.MessageId
       response: messages.RawMessageResponse
@@ -69,6 +89,11 @@ service:
       method: PATCH
       path: /{message_id}
       display-name: Update Message
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:messages update --inbox-id <inbox_id> --message-id <message_id> --add-label read --remove-label unread
+        ```
       path-parameters:
         message_id: messages.MessageId
       request: messages.UpdateMessageRequest
@@ -81,6 +106,11 @@ service:
       method: POST
       path: /send
       display-name: Send Message
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:messages send --inbox-id <inbox_id> --to recipient@example.com --subject "Hello" --text "Body"
+        ```
       request: messages.SendMessageRequest
       response: messages.SendMessageResponse
       errors:
@@ -92,6 +122,11 @@ service:
       method: POST
       path: /{message_id}/reply
       display-name: Reply To Message
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:messages reply --inbox-id <inbox_id> --message-id <message_id> --text "Reply text"
+        ```
       path-parameters:
         message_id: messages.MessageId
       request: messages.ReplyToMessageRequest
@@ -105,6 +140,11 @@ service:
       method: POST
       path: /{message_id}/reply-all
       display-name: Reply All Message
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:messages reply-all --inbox-id <inbox_id> --message-id <message_id> --text "Reply text"
+        ```
       path-parameters:
         message_id: messages.MessageId
       request: messages.ReplyAllMessageRequest
@@ -118,6 +158,11 @@ service:
       method: POST
       path: /{message_id}/forward
       display-name: Forward Message
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:messages forward --inbox-id <inbox_id> --message-id <message_id> --to recipient@example.com
+        ```
       path-parameters:
         message_id: messages.MessageId
       request: messages.SendMessageRequest

--- a/fern/definition/inboxes/metrics.yml
+++ b/fern/definition/inboxes/metrics.yml
@@ -17,6 +17,11 @@ service:
       method: GET
       path: ""
       display-name: Query Metrics
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:metrics query --inbox-id <inbox_id>
+        ```
       request:
         name: QueryMetricsRequest
         query-parameters:

--- a/fern/definition/inboxes/threads.yml
+++ b/fern/definition/inboxes/threads.yml
@@ -18,6 +18,11 @@ service:
       method: GET
       path: ""
       display-name: List Threads
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:threads list --inbox-id <inbox_id>
+        ```
       request:
         name: ListThreadsRequest
         query-parameters:
@@ -38,6 +43,11 @@ service:
       method: GET
       path: /{thread_id}
       display-name: Get Thread
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:threads retrieve --inbox-id <inbox_id> --thread-id <thread_id>
+        ```
       path-parameters:
         thread_id: threads.ThreadId
       response: threads.Thread
@@ -48,6 +58,11 @@ service:
       method: GET
       path: /{thread_id}/attachments/{attachment_id}
       display-name: Get Attachment
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:threads get-attachment --inbox-id <inbox_id> --thread-id <thread_id> --attachment-id <attachment_id>
+        ```
       path-parameters:
         thread_id: threads.ThreadId
         attachment_id: attachments.AttachmentId
@@ -59,7 +74,13 @@ service:
       method: DELETE
       path: /{thread_id}
       display-name: Delete Thread
-      docs: Moves the thread to trash by adding a trash label to all messages. If the thread is already in trash, it will be permanently deleted. Use `permanent=true` to force permanent deletion.
+      docs: |
+        Moves the thread to trash by adding a trash label to all messages. If the thread is already in trash, it will be permanently deleted. Use `permanent=true` to force permanent deletion.
+
+        **CLI:**
+        ```bash
+        agentmail inboxes:threads delete --inbox-id <inbox_id> --thread-id <thread_id>
+        ```
       path-parameters:
         thread_id: threads.ThreadId
       request:

--- a/fern/definition/lists.yml
+++ b/fern/definition/lists.yml
@@ -92,6 +92,11 @@ service:
       method: GET
       path: ""
       display-name: List Entries
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail lists list --direction <direction> --type <type>
+        ```
       request:
         name: ListListEntriesRequest
         query-parameters:
@@ -103,6 +108,11 @@ service:
       method: GET
       path: /{entry}
       display-name: Get List Entry
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail lists retrieve --direction <direction> --type <type> --entry <entry>
+        ```
       path-parameters:
         entry:
           type: string
@@ -115,6 +125,11 @@ service:
       method: POST
       path: ""
       display-name: Create List Entry
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail lists create --direction <direction> --type <type> --entry user@example.com
+        ```
       request: CreateListEntryRequest
       response: ListEntry
       errors:
@@ -124,6 +139,11 @@ service:
       method: DELETE
       path: /{entry}
       display-name: Delete List Entry
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail lists delete --direction <direction> --type <type> --entry <entry>
+        ```
       path-parameters:
         entry:
           type: string

--- a/fern/definition/metrics.yml
+++ b/fern/definition/metrics.yml
@@ -70,6 +70,11 @@ service:
       method: GET
       path: ""
       display-name: Query Metrics
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail metrics list
+        ```
       request:
         name: QueryMetricsRequest
         query-parameters:

--- a/fern/definition/pods/__package__.yml
+++ b/fern/definition/pods/__package__.yml
@@ -61,6 +61,11 @@ service:
       method: GET
       path: ""
       display-name: List Pods
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods list
+        ```
       request:
         name: ListPodsRequest
         query-parameters:
@@ -73,6 +78,11 @@ service:
       method: GET
       path: /{pod_id}
       display-name: Get Pod
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods retrieve --pod-id <pod_id>
+        ```
       path-parameters:
         pod_id: PodId
       response: Pod
@@ -83,6 +93,11 @@ service:
       method: POST
       path: ""
       display-name: Create Pod
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods create --client-id my-pod
+        ```
       request: CreatePodRequest
       response: Pod
       errors:
@@ -92,6 +107,11 @@ service:
       method: DELETE
       path: /{pod_id}
       display-name: Delete Pod
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods delete --pod-id <pod_id>
+        ```
       path-parameters:
         pod_id: PodId
       errors:

--- a/fern/definition/pods/api-keys.yml
+++ b/fern/definition/pods/api-keys.yml
@@ -17,6 +17,11 @@ service:
       method: GET
       path: ""
       display-name: List API Keys
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:api-keys list --pod-id <pod_id>
+        ```
       request:
         name: ListApiKeysRequest
         query-parameters:
@@ -30,6 +35,11 @@ service:
       method: POST
       path: ""
       display-name: Create API Key
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:api-keys create --pod-id <pod_id> --name "My Key"
+        ```
       request: api-keys.CreateApiKeyRequest
       response: api-keys.CreateApiKeyResponse
       errors:
@@ -40,6 +50,11 @@ service:
       method: DELETE
       path: /{api_key_id}
       display-name: Delete API Key
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:api-keys delete --pod-id <pod_id> --api-key-id <api_key_id>
+        ```
       path-parameters:
         api_key_id: api-keys.ApiKeyId
       errors:

--- a/fern/definition/pods/domains.yml
+++ b/fern/definition/pods/domains.yml
@@ -17,6 +17,11 @@ service:
       method: GET
       path: ""
       display-name: List Domains
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:domains list --pod-id <pod_id>
+        ```
       request:
         name: ListDomainsRequest
         query-parameters:
@@ -31,6 +36,11 @@ service:
       method: GET
       path: /{domain_id}
       display-name: Get Domain
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:domains retrieve --pod-id <pod_id> --domain-id <domain_id>
+        ```
       path-parameters:
         domain_id: domains.DomainId
       response: domains.Domain
@@ -41,6 +51,11 @@ service:
       method: GET
       path: /{domain_id}/zone-file
       display-name: Get Zone File
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:domains get-zone-file --pod-id <pod_id> --domain-id <domain_id>
+        ```
       path-parameters:
         domain_id: domains.DomainId
       response: file
@@ -51,6 +66,11 @@ service:
       method: POST
       path: ""
       display-name: Create Domain
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:domains create --pod-id <pod_id> --domain example.com
+        ```
       request: domains.CreateDomainRequest
       response: domains.Domain
       errors:
@@ -60,6 +80,11 @@ service:
       method: PATCH
       path: /{domain_id}
       display-name: Update Domain
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:domains update --pod-id <pod_id> --domain-id <domain_id>
+        ```
       path-parameters:
         domain_id: domains.DomainId
       request: domains.UpdateDomainRequest
@@ -71,6 +96,11 @@ service:
       method: DELETE
       path: /{domain_id}
       display-name: Delete Domain
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:domains delete --pod-id <pod_id> --domain-id <domain_id>
+        ```
       path-parameters:
         domain_id: domains.DomainId
       errors:
@@ -80,6 +110,11 @@ service:
       method: POST
       path: /{domain_id}/verify
       display-name: Verify Domain
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:domains verify --pod-id <pod_id> --domain-id <domain_id>
+        ```
       path-parameters:
         domain_id: domains.DomainId
       errors:

--- a/fern/definition/pods/drafts.yml
+++ b/fern/definition/pods/drafts.yml
@@ -18,6 +18,11 @@ service:
       method: GET
       path: ""
       display-name: List Drafts
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:drafts list --pod-id <pod_id>
+        ```
       request:
         name: ListDraftsRequest
         query-parameters:
@@ -35,6 +40,11 @@ service:
       method: GET
       path: /{draft_id}
       display-name: Get Draft
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:drafts retrieve --pod-id <pod_id> --draft-id <draft_id>
+        ```
       path-parameters:
         draft_id: drafts.DraftId
       response: drafts.Draft
@@ -45,6 +55,11 @@ service:
       method: GET
       path: /{draft_id}/attachments/{attachment_id}
       display-name: Get Attachment
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:drafts get-attachment --pod-id <pod_id> --draft-id <draft_id> --attachment-id <attachment_id>
+        ```
       path-parameters:
         draft_id: drafts.DraftId
         attachment_id: attachments.AttachmentId

--- a/fern/definition/pods/inboxes.yml
+++ b/fern/definition/pods/inboxes.yml
@@ -17,6 +17,11 @@ service:
       method: GET
       path: ""
       display-name: List Inboxes
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:inboxes list --pod-id <pod_id>
+        ```
       request:
         name: ListInboxesRequest
         query-parameters:
@@ -31,6 +36,11 @@ service:
       method: GET
       path: /{inbox_id}
       display-name: Get Inbox
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:inboxes retrieve --pod-id <pod_id> --inbox-id <inbox_id>
+        ```
       path-parameters:
         inbox_id: inboxes.InboxId
       response: inboxes.Inbox
@@ -41,6 +51,11 @@ service:
       method: POST
       path: ""
       display-name: Create Inbox
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:inboxes create --pod-id <pod_id> --username myagent --domain example.com
+        ```
       request: inboxes.CreateInboxRequest
       response: inboxes.Inbox
       errors:
@@ -50,6 +65,11 @@ service:
       method: PATCH
       path: /{inbox_id}
       display-name: Update Inbox
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:inboxes update --pod-id <pod_id> --inbox-id <inbox_id>
+        ```
       path-parameters:
         inbox_id: inboxes.InboxId
       request: inboxes.UpdateInboxRequest
@@ -61,6 +81,11 @@ service:
       method: DELETE
       path: /{inbox_id}
       display-name: Delete Inbox
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:inboxes delete --pod-id <pod_id> --inbox-id <inbox_id>
+        ```
       path-parameters:
         inbox_id: inboxes.InboxId
       errors:

--- a/fern/definition/pods/lists.yml
+++ b/fern/definition/pods/lists.yml
@@ -19,6 +19,11 @@ service:
       method: GET
       path: ""
       display-name: List Entries
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:lists list --pod-id <pod_id> --direction <direction> --type <type>
+        ```
       request:
         name: ListListEntriesRequest
         query-parameters:
@@ -30,6 +35,11 @@ service:
       method: GET
       path: /{entry}
       display-name: Get List Entry
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:lists retrieve --pod-id <pod_id> --direction <direction> --type <type> --entry <entry>
+        ```
       path-parameters:
         entry:
           type: string
@@ -42,6 +52,11 @@ service:
       method: POST
       path: ""
       display-name: Create List Entry
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:lists create --pod-id <pod_id> --direction <direction> --type <type> --entry user@example.com
+        ```
       request: lists.CreateListEntryRequest
       response: lists.PodListEntry
       errors:
@@ -51,6 +66,11 @@ service:
       method: DELETE
       path: /{entry}
       display-name: Delete List Entry
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:lists delete --pod-id <pod_id> --direction <direction> --type <type> --entry <entry>
+        ```
       path-parameters:
         entry:
           type: string

--- a/fern/definition/pods/metrics.yml
+++ b/fern/definition/pods/metrics.yml
@@ -17,6 +17,11 @@ service:
       method: GET
       path: ""
       display-name: Query Metrics
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:metrics query --pod-id <pod_id>
+        ```
       request:
         name: QueryMetricsRequest
         query-parameters:

--- a/fern/definition/pods/threads.yml
+++ b/fern/definition/pods/threads.yml
@@ -18,6 +18,11 @@ service:
       method: GET
       path: ""
       display-name: List Threads
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:threads list --pod-id <pod_id>
+        ```
       request:
         name: ListThreadsRequest
         query-parameters:
@@ -38,6 +43,11 @@ service:
       method: GET
       path: /{thread_id}
       display-name: Get Thread
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:threads retrieve --pod-id <pod_id> --thread-id <thread_id>
+        ```
       path-parameters:
         thread_id: threads.ThreadId
       response: threads.Thread
@@ -48,6 +58,11 @@ service:
       method: GET
       path: /{thread_id}/attachments/{attachment_id}
       display-name: Get Attachment
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:threads get-attachment --pod-id <pod_id> --thread-id <thread_id> --attachment-id <attachment_id>
+        ```
       path-parameters:
         thread_id: threads.ThreadId
         attachment_id: attachments.AttachmentId
@@ -59,7 +74,13 @@ service:
       method: DELETE
       path: /{thread_id}
       display-name: Delete Thread
-      docs: Moves the thread to trash by adding a trash label to all messages. If the thread is already in trash, it will be permanently deleted. Use `permanent=true` to force permanent deletion.
+      docs: |
+        Moves the thread to trash by adding a trash label to all messages. If the thread is already in trash, it will be permanently deleted. Use `permanent=true` to force permanent deletion.
+
+        **CLI:**
+        ```bash
+        agentmail pods:threads delete --pod-id <pod_id> --thread-id <thread_id>
+        ```
       path-parameters:
         thread_id: threads.ThreadId
       request:

--- a/fern/definition/threads.yml
+++ b/fern/definition/threads.yml
@@ -127,6 +127,11 @@ service:
       method: GET
       path: ""
       display-name: List Threads
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail threads list
+        ```
       request:
         name: ListThreadsRequest
         query-parameters:
@@ -147,6 +152,11 @@ service:
       method: GET
       path: /{thread_id}
       display-name: Get Thread
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail threads retrieve --thread-id <thread_id>
+        ```
       path-parameters:
         thread_id: ThreadId
       response: Thread
@@ -157,6 +167,11 @@ service:
       method: GET
       path: /{thread_id}/attachments/{attachment_id}
       display-name: Get Attachment
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail threads retrieve-attachment --thread-id <thread_id> --attachment-id <attachment_id>
+        ```
       path-parameters:
         thread_id: ThreadId
         attachment_id: attachments.AttachmentId
@@ -168,7 +183,13 @@ service:
       method: DELETE
       path: /{thread_id}
       display-name: Delete Thread
-      docs: Moves the thread to trash by adding a trash label to all messages. If the thread is already in trash, it will be permanently deleted. Use `permanent=true` to force permanent deletion.
+      docs: |
+        Moves the thread to trash by adding a trash label to all messages. If the thread is already in trash, it will be permanently deleted. Use `permanent=true` to force permanent deletion.
+
+        **CLI:**
+        ```bash
+        agentmail threads delete --thread-id <thread_id>
+        ```
       path-parameters:
         thread_id: ThreadId
       request:

--- a/fern/definition/webhooks/__package__.yml
+++ b/fern/definition/webhooks/__package__.yml
@@ -80,6 +80,11 @@ service:
       method: GET
       path: ""
       display-name: List Webhooks
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail webhooks list
+        ```
       request:
         name: ListWebhooksRequest
         query-parameters:
@@ -92,6 +97,11 @@ service:
       method: GET
       path: /{webhook_id}
       display-name: Get Webhook
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail webhooks retrieve --webhook-id <webhook_id>
+        ```
       path-parameters:
         webhook_id: WebhookId
       response: Webhook
@@ -102,6 +112,11 @@ service:
       method: POST
       path: ""
       display-name: Create Webhook
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail webhooks create --url https://example.com/webhook --event-type message.received
+        ```
       request: CreateWebhookRequest
       response: Webhook
       errors:
@@ -111,6 +126,11 @@ service:
       method: PATCH
       path: /{webhook_id}
       display-name: Update Webhook
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail webhooks update --webhook-id <webhook_id> --url https://new-url.com/webhook
+        ```
       path-parameters:
         webhook_id: WebhookId
       request: UpdateWebhookRequest
@@ -123,6 +143,11 @@ service:
       method: DELETE
       path: /{webhook_id}
       display-name: Delete Webhook
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail webhooks delete --webhook-id <webhook_id>
+        ```
       path-parameters:
         webhook_id: WebhookId
       errors:

--- a/fern/definition/webhooks/__package__.yml
+++ b/fern/definition/webhooks/__package__.yml
@@ -129,7 +129,7 @@ service:
       docs: |
         **CLI:**
         ```bash
-        agentmail webhooks update --webhook-id <webhook_id> --url https://new-url.com/webhook
+        agentmail webhooks update --webhook-id <webhook_id> --add-inbox-id <inbox_id>
         ```
       path-parameters:
         webhook_id: WebhookId

--- a/fern/pages/core-concepts/attachments.mdx
+++ b/fern/pages/core-concepts/attachments.mdx
@@ -61,6 +61,18 @@ const sentMessage = await client.inboxes.messages.send("reports@agentmail.to", {
 });
 ````
 
+```bash title="CLI"
+# send a message with a base64-encoded attachment
+agentmail inboxes:messages send \
+  --inbox-id reports@agentmail.to \
+  --to supervisor@example.com \
+  --subject "Q4 Financial Report" \
+  --text "Please see the attached report." \
+  --attachment.content "VGhpcyBpcyB0aGUgY29udGVudCBvZiBvdXIgcmVwb3J0Lg==" \
+  --attachment.filename "Q4-report.txt" \
+  --attachment.content-type "text/plain"
+```
+
 </CodeBlocks>
 
 ## Retrieving `Attachments`
@@ -109,6 +121,14 @@ const fileData = await client.inboxes.messages.get_attachment(
 // fs.writeFileSync('downloaded_file.pdf', fileData);
 ````
 
+```bash title="CLI"
+# get an attachment from a specific message
+agentmail inboxes:messages get-attachment \
+  --inbox-id inbox_123 \
+  --message-id "<def456@agentmail.to>" \
+  --attachment-id attach_789
+```
+
 </CodeBlocks>
 
 ### From a Specific `Thread`
@@ -140,6 +160,14 @@ const fileData = await client.inboxes.threads.get_attachment(
   attachmentId
 );
 ````
+
+```bash title="CLI"
+# get an attachment from a specific thread
+agentmail inboxes:threads get-attachment \
+  --inbox-id inbox_123 \
+  --thread-id thread_abc \
+  --attachment-id attach_789
+```
 
 </CodeBlocks>
 

--- a/fern/pages/core-concepts/drafts.mdx
+++ b/fern/pages/core-concepts/drafts.mdx
@@ -184,7 +184,7 @@ agentmail inboxes:drafts create \
   --to prospect@example.com \
   --subject "Following up on our conversation" \
   --text "Hi, just wanted to follow up on our chat yesterday..." \
-  --send-at 2026-03-31T09:00:00Z
+  --send-at 2026-04-01T09:00:00Z
 ```
 </CodeBlocks>
 
@@ -368,7 +368,7 @@ agentmail inboxes:drafts create \
   --subject "Re: Quick question about your workflow" \
   --text "Hi again — just bumping this in case it got buried..." \
   --in-reply-to initial_message_id \
-  --send-at 2026-04-02T09:00:00Z
+  --send-at 2026-04-03T09:00:00Z
 ```
 </CodeBlocks>
 

--- a/fern/pages/core-concepts/drafts.mdx
+++ b/fern/pages/core-concepts/drafts.mdx
@@ -55,6 +55,14 @@ const newDraft = await client.inboxes.drafts.create(
 console.log(`Draft created successfully with ID: ${newDraft.id}`);
 ````
 
+```bash title="CLI"
+# create a draft in an inbox
+agentmail inboxes:drafts create \
+  --inbox-id outbound@domain.com \
+  --to review-team@example.com \
+  --subject "[NEEDS REVIEW] Agent's proposed response"
+```
+
 </CodeBlocks>
 
 ### 2. Get `Draft`
@@ -77,6 +85,13 @@ const draft = await client.inboxes.drafts.get(
 )
 
 ````
+
+```bash title="CLI"
+# retrieve a draft by id
+agentmail inboxes:drafts retrieve \
+  --inbox-id my_inbox@domain.com \
+  --draft-id draft_id_123
+```
 
 </CodeBlocks>
 
@@ -101,6 +116,13 @@ const sentMessage = await client.inboxes.drafts.send('my_inbox@domain.com', 'dra
 
 console.log(`Draft sent! New message ID: ${sentMessage.message_id}`);
 ````
+
+```bash title="CLI"
+# send a draft
+agentmail inboxes:drafts send \
+  --inbox-id my_inbox@domain.com \
+  --draft-id draft_id_123
+```
 
 </CodeBlocks>
 
@@ -154,6 +176,16 @@ const scheduledDraft = await client.inboxes.drafts.create(
 console.log(`Draft scheduled for ${scheduledDraft.sendAt}`);
 // sendStatus will be "scheduled"
 ```
+
+```bash title="CLI"
+# schedule a draft for tomorrow at 9:00 am utc
+agentmail inboxes:drafts create \
+  --inbox-id outreach@domain.com \
+  --to prospect@example.com \
+  --subject "Following up on our conversation" \
+  --text "Hi, just wanted to follow up on our chat yesterday..." \
+  --send-at 2026-03-31T09:00:00Z
+```
 </CodeBlocks>
 
 ### Cancel or Reschedule
@@ -195,6 +227,19 @@ await client.inboxes.drafts.delete(
     scheduledDraft.draftId
 );
 ```
+
+```bash title="CLI"
+# reschedule to a different time
+agentmail inboxes:drafts update \
+  --inbox-id outreach@domain.com \
+  --draft-id scheduled_draft_id \
+  --send-at 2026-04-02T14:00:00Z
+
+# or cancel by deleting the draft entirely
+agentmail inboxes:drafts delete \
+  --inbox-id outreach@domain.com \
+  --draft-id scheduled_draft_id
+```
 </CodeBlocks>
 
 ### List Scheduled `Drafts`
@@ -223,6 +268,13 @@ const scheduled = await client.inboxes.drafts.list(
 for (const draft of scheduled.drafts) {
     console.log(`${draft.subject} — scheduled for ${draft.sendAt} (${draft.sendStatus})`);
 }
+```
+
+```bash title="CLI"
+# list all scheduled drafts in an inbox
+agentmail inboxes:drafts list \
+  --inbox-id outreach@domain.com \
+  --label scheduled
 ```
 </CodeBlocks>
 
@@ -300,6 +352,24 @@ await client.inboxes.threads.update(inboxId, initial.threadId, {
     addLabels: [`follow-up:${followUp.draftId}`]
 });
 ```
+
+```bash title="CLI"
+# send the initial email
+agentmail inboxes:messages send \
+  --inbox-id outreach@domain.com \
+  --to prospect@example.com \
+  --subject "Quick question about your workflow" \
+  --text "Hi, I noticed your team is scaling quickly..."
+
+# schedule follow-up for 3 days later
+agentmail inboxes:drafts create \
+  --inbox-id outreach@domain.com \
+  --to prospect@example.com \
+  --subject "Re: Quick question about your workflow" \
+  --text "Hi again — just bumping this in case it got buried..." \
+  --in-reply-to initial_message_id \
+  --send-at 2026-04-02T09:00:00Z
+```
 </CodeBlocks>
 
 **2. Cancel on reply via webhook:**
@@ -367,6 +437,11 @@ const allDrafts = await client.drafts.list();
 
 console.log(`Found ${allDrafts.count} drafts pending review.`);
 ````
+
+```bash title="CLI"
+# list all drafts across the entire organization
+agentmail drafts list
+```
 
 </CodeBlocks>
 

--- a/fern/pages/core-concepts/inboxes.mdx
+++ b/fern/pages/core-concepts/inboxes.mdx
@@ -117,6 +117,20 @@ console.log(`Total Inboxes: ${allInboxes.count}`);
 
 ```
 
+```bash title="CLI"
+# create an inbox
+agentmail inboxes create \
+  --username docs-testing \
+  --domain domain.com \
+  --display-name "Docs Tester"
+
+# retrieve an inbox
+agentmail inboxes retrieve --inbox-id my_name@domain.com
+
+# list all inboxes
+agentmail inboxes list
+```
+
 </CodeBlocks>
 
 <Tip>

--- a/fern/pages/core-concepts/labels.mdx
+++ b/fern/pages/core-concepts/labels.mdx
@@ -71,6 +71,17 @@ const sentMessage = await client.inboxes.messages.send(
 );
 ```
 
+```bash title="CLI"
+# send a message with labels
+agentmail inboxes:messages send \
+  --inbox-id outbound@agentmail.to \
+  --to test@example.com \
+  --subject "Following up on our conversation" \
+  --text "Here is the information you requested." \
+  --label follow-up \
+  --label q4-campaign
+```
+
 </CodeBlocks>
 
 ### 2. Adding or Removing `Labels` on an Existing `Message`
@@ -109,6 +120,15 @@ await client.inboxes.messages.update(
 
 ````
 
+```bash title="CLI"
+# add and remove labels on an existing message
+agentmail inboxes:messages update \
+  --inbox-id outbound@domain.com \
+  --message-id "<abc123@agentmail.to>" \
+  --add-label resolved \
+  --remove-label unresolved
+```
+
 </CodeBlocks>
 
 ### 3. Filtering by `Labels`
@@ -145,6 +165,14 @@ const filteredThreads = await client.inboxes.threads.list(
 
 console.log(`Found ${filteredThreads.count} threads that need a follow-up.`);
 ````
+
+```bash title="CLI"
+# list messages filtered by labels
+agentmail inboxes:messages list \
+  --inbox-id outbound-agent@domain.com \
+  --label q4-campaign \
+  --label follow_up
+```
 
 </CodeBlocks>
 

--- a/fern/pages/core-concepts/labels.mdx
+++ b/fern/pages/core-concepts/labels.mdx
@@ -167,8 +167,8 @@ console.log(`Found ${filteredThreads.count} threads that need a follow-up.`);
 ````
 
 ```bash title="CLI"
-# list messages filtered by labels
-agentmail inboxes:messages list \
+# list threads filtered by labels
+agentmail inboxes:threads list \
   --inbox-id outbound-agent@domain.com \
   --label q4-campaign \
   --label follow_up

--- a/fern/pages/core-concepts/lists.mdx
+++ b/fern/pages/core-concepts/lists.mdx
@@ -56,6 +56,14 @@ entries = client.lists.list("receive", "allow", limit=10)
 ```typescript title="TypeScript"
 const entries = await client.lists.list("receive", "allow", { limit: 10 });
 ```
+
+```bash title="CLI"
+# list entries from the receive allowlist
+agentmail lists list \
+  --direction receive \
+  --type allow \
+  --limit 10
+```
 </CodeBlocks>
 
 ### Create entry
@@ -78,6 +86,21 @@ await client.lists.create("receive", "allow", { entry: "partner@example.com" });
 // block list - reason optional
 await client.lists.create("receive", "block", { entry: "spam@example.com", reason: "spam" });
 ```
+
+```bash title="CLI"
+# allow list - no reason needed
+agentmail lists create \
+  --direction receive \
+  --type allow \
+  --entry partner@example.com
+
+# block list - reason optional
+agentmail lists create \
+  --direction receive \
+  --type block \
+  --entry spam@example.com \
+  --reason spam
+```
 </CodeBlocks>
 
 ### Get entry
@@ -92,6 +115,14 @@ entry = client.lists.get("receive", "allow", entry="partner@example.com")
 ```typescript title="TypeScript"
 const entry = await client.lists.get("receive", "allow", "partner@example.com");
 ```
+
+```bash title="CLI"
+# retrieve a specific entry
+agentmail lists retrieve \
+  --direction receive \
+  --type allow \
+  --entry partner@example.com
+```
 </CodeBlocks>
 
 ### Delete entry
@@ -105,6 +136,14 @@ client.lists.delete("receive", "allow", entry="partner@example.com")
 
 ```typescript title="TypeScript"
 await client.lists.delete("receive", "allow", "partner@example.com");
+```
+
+```bash title="CLI"
+# delete an entry
+agentmail lists delete \
+  --direction receive \
+  --type allow \
+  --entry partner@example.com
 ```
 </CodeBlocks>
 
@@ -132,6 +171,21 @@ await client.inboxes.lists.create("inbox_id", "receive", "allow", {
 // List inbox-level entries
 const entries = await client.inboxes.lists.list("inbox_id", "receive", "allow");
 ```
+
+```bash title="CLI"
+# add to an inbox-level receive allowlist
+agentmail inboxes:lists create \
+  --inbox-id inbox_id \
+  --direction receive \
+  --type allow \
+  --entry vip@example.com
+
+# list inbox-level entries
+agentmail inboxes:lists list \
+  --inbox-id inbox_id \
+  --direction receive \
+  --type allow
+```
 </CodeBlocks>
 
 ### Reply lists
@@ -147,6 +201,14 @@ client.lists.create("reply", "allow", entry="nobu.com")
 ```typescript title="TypeScript"
 // Only allow replies from a specific domain
 await client.lists.create("reply", "allow", { entry: "nobu.com" });
+```
+
+```bash title="CLI"
+# only allow replies from a specific domain
+agentmail lists create \
+  --direction reply \
+  --type allow \
+  --entry nobu.com
 ```
 </CodeBlocks>
 

--- a/fern/pages/core-concepts/messages.mdx
+++ b/fern/pages/core-concepts/messages.mdx
@@ -79,6 +79,18 @@ const sentMessage = await client.inboxes.messages.send(
 console.log(`Message sent successfully with ID: ${sentMessage.id}`);
 ````
 
+```bash title="CLI"
+# send a new message with labels
+agentmail inboxes:messages send \
+  --inbox-id outreach@agentmail.to \
+  --to recipient@domain.com \
+  --subject "[YC S25] Founder Reachout " \
+  --text "Hello, I'm Michael, and I'm a founder at AgentMail..." \
+  --html "<div dir=\"ltr\">Hello,<br><br>I'm Michael, and I'm a founder at AgentMail..." \
+  --label outreach \
+  --label startup
+```
+
 </CodeBlocks>
 
 <Warning>
@@ -102,6 +114,11 @@ const allMessages = await client.inboxes.messages.list("outreach@agentmail.to")
 
 console.log(`Found ${allMessages.count} messages in the inbox.`);
 ````
+
+```bash title="CLI"
+# list all messages in an inbox
+agentmail inboxes:messages list --inbox-id outreach@agentmail.to
+```
 
 </CodeBlocks>
 
@@ -145,6 +162,16 @@ const reply = await client.inboxes.messages.reply(
 console.log(`Reply sent successfully with ID: ${reply.id}`);
 ````
 
+```bash title="CLI"
+# reply to a message with an attachment
+agentmail inboxes:messages reply \
+  --inbox-id my_inbox@domain.com \
+  --message-id "<abc123@agentmail.to>" \
+  --text "Thanks for the referral!" \
+  --attachment.content "resume" \
+  --attachment.filename "resume.pdf"
+```
+
 </CodeBlocks>
 
 <Callout>
@@ -173,6 +200,13 @@ await client.inboxes.messages.get(
 )
 
 console.log(`Retrieved message with subject: ${message.subject}`);
+```
+
+```bash title="CLI"
+# retrieve a specific message
+agentmail inboxes:messages retrieve \
+  --inbox-id my_inbox@agentmail.to \
+  --message-id "<abc123@agentmail.to>"
 ```
 </CodeBlocks>
 
@@ -479,6 +513,20 @@ const unread = await client.inboxes.messages.list(
   "agent@agentmail.to",
   { labels: ["unread"] }
 );
+```
+
+```bash title="CLI"
+# mark a message as read after processing
+agentmail inboxes:messages update \
+  --inbox-id agent@agentmail.to \
+  --message-id "<message_id>" \
+  --add-label read \
+  --remove-label unread
+
+# only fetch unread messages
+agentmail inboxes:messages list \
+  --inbox-id agent@agentmail.to \
+  --label unread
 ```
 </CodeBlocks>
 

--- a/fern/pages/core-concepts/permissions.mdx
+++ b/fern/pages/core-concepts/permissions.mdx
@@ -188,6 +188,27 @@ const key = await client.apiKeys.create({
 
 console.log(key.apiKey);
 ```
+
+```bash title="CLI"
+# create a read-only api key
+agentmail api-keys create \
+  --name "read-only-agent" \
+  --permissions '{
+    "inbox_read": true,
+    "thread_read": true,
+    "message_read": true,
+    "draft_read": true,
+    "webhook_read": true,
+    "domain_read": true,
+    "list_entry_read": true,
+    "metrics_read": true,
+    "api_key_read": true,
+    "pod_read": true,
+    "label_spam_read": true,
+    "label_blocked_read": true,
+    "label_trash_read": true
+  }'
+```
 </CodeBlocks>
 
 ### No-spam key
@@ -279,6 +300,49 @@ const key = await client.apiKeys.create({
     podDelete: true,
   },
 });
+```
+
+```bash title="CLI"
+# create a key with full access but no spam/blocked/trash visibility
+agentmail api-keys create \
+  --name "clean-inbox-agent" \
+  --permissions '{
+    "inbox_read": true,
+    "inbox_create": true,
+    "inbox_update": true,
+    "inbox_delete": true,
+    "thread_read": true,
+    "thread_delete": true,
+    "message_read": true,
+    "message_send": true,
+    "message_update": true,
+    "label_spam_read": false,
+    "label_blocked_read": false,
+    "label_trash_read": false,
+    "draft_read": true,
+    "draft_create": true,
+    "draft_update": true,
+    "draft_delete": true,
+    "draft_send": true,
+    "webhook_read": true,
+    "webhook_create": true,
+    "webhook_update": true,
+    "webhook_delete": true,
+    "domain_read": true,
+    "domain_create": true,
+    "domain_update": true,
+    "domain_delete": true,
+    "list_entry_read": true,
+    "list_entry_create": true,
+    "list_entry_delete": true,
+    "metrics_read": true,
+    "api_key_read": true,
+    "api_key_create": true,
+    "api_key_delete": true,
+    "pod_read": true,
+    "pod_create": true,
+    "pod_delete": true
+  }'
 ```
 </CodeBlocks>
 

--- a/fern/pages/core-concepts/threads.mdx
+++ b/fern/pages/core-concepts/threads.mdx
@@ -40,6 +40,12 @@ const inboxThreads = await client.inboxes.threads.list("inbound-agent@agentmail.
 console.log(`Found ${inboxThreads.count} threads in Inbox ${inboxId}.`);
 ````
 
+```bash title="CLI"
+# list all threads within a specific inbox
+agentmail inboxes:threads list \
+  --inbox-id inbound-agent@agentmail.to
+```
+
 </CodeBlocks>
 
 ### Listing `Threads` Across an `Organization`
@@ -65,6 +71,11 @@ const allThreads = await client.threads.list();
 
 console.log(`Found ${allThreads.count} threads across the entire organization.`);
 ````
+
+```bash title="CLI"
+# list all threads across the entire organization
+agentmail threads list
+```
 
 </CodeBlocks>
 
@@ -102,6 +113,12 @@ const thread = await client.threads.get(
 
 console.log(`Retrieved thread ${thread.thread_id} with ${thread.messages.length} messages.`);
 ````
+
+```bash title="CLI"
+# retrieve a single thread by id
+agentmail threads retrieve \
+  --thread-id thread_456def
+```
 
 </CodeBlocks>
 

--- a/fern/pages/get-started/quickstart.mdx
+++ b/fern/pages/get-started/quickstart.mdx
@@ -15,6 +15,10 @@ description: Follow this guide to make your first AgentMail API request and crea
   ```bash title="TypeScript"
   npm install agentmail
   ```
+
+  ```bash title="CLI"
+  npm install -g agentmail-cli
+  ```
 </CodeBlocks>
 
 Get your API key from the [Console](https://console.agentmail.to) and replace `am_...` in the code below.
@@ -36,6 +40,18 @@ Get your API key from the [Console](https://console.agentmail.to) and replace `a
     const inbox = await client.inboxes.create();
     await client.inboxes.messages.send(inbox.inboxId, { to: "user@example.com", subject: "Hello", text: "Hello from my agent!" });
   })();
+  ```
+
+  ```bash title="CLI"
+  # create an inbox
+  agentmail inboxes create
+
+  # send an email (replace <inbox_id> with the id from above)
+  agentmail inboxes:messages send \
+    --inbox-id <inbox_id> \
+    --to user@example.com \
+    --subject "Hello" \
+    --text "Hello from my agent!"
   ```
 </CodeBlocks>
 
@@ -180,6 +196,10 @@ This guide will walk you through installing the AgentMail SDK, authenticating wi
       ```bash title="Node"
       npm install agentmail dotenv
       ```
+
+      ```bash title="CLI"
+      npm install -g agentmail-cli
+      ```
     </CodeBlocks>
 
   </Step>
@@ -249,6 +269,18 @@ This guide will walk you through installing the AgentMail SDK, authenticating wi
         console.error(error);
         process.exit(1);
       });
+      ```
+
+      ```bash title="CLI"
+      # create an inbox
+      agentmail inboxes create
+
+      # send an email (replace <inbox_id> with the id from above)
+      agentmail inboxes:messages send \
+        --inbox-id <inbox_id> \
+        --to your-email@example.com \
+        --subject "Hello from AgentMail!" \
+        --text "This is my first email sent with the AgentMail API."
       ```
     </CodeBlocks>
     <Note>

--- a/fern/pages/guides/domains/custom-domains.mdx
+++ b/fern/pages/guides/domains/custom-domains.mdx
@@ -90,6 +90,11 @@ Choose your preferred method to create a domain and get the required DNS records
       console.log("Domain created:", domain);
       console.log("DNS Records:", domain.records);
       ```
+
+      ```bash title="CLI"
+      # create domain with default settings
+      agentmail domains create --domain your-domain.com
+      ```
     </CodeBlocks>
 
 <Callout type="info" title="Idempotent Requests">

--- a/fern/pages/guides/multi-tenancy.mdx
+++ b/fern/pages/guides/multi-tenancy.mdx
@@ -54,6 +54,19 @@ const domain = await client.pods.domains.create(pod.podId, {
   domain: "acme.com",
 });
 ```
+
+```bash title="CLI"
+# create an inbox in the pod
+agentmail pods:inboxes create \
+  --pod-id <pod-id> \
+  --username support \
+  --display-name "Acme Support"
+
+# add a custom domain to the pod
+agentmail pods:domains create \
+  --pod-id <pod-id> \
+  --domain acme.com
+```
 </CodeBlocks>
 
 ## Scoped API Keys
@@ -85,6 +98,13 @@ const scopedKey = await client.pods.apiKeys.create(pod.podId, {
 
 // This is the only time you'll see the full key, so store it
 console.log(scopedKey.apiKey);
+```
+
+```bash title="CLI"
+# create a key scoped to acme's pod
+agentmail api-keys create \
+  --name "acme-service-key" \
+  --pod-id <pod-id>
 ```
 </CodeBlocks>
 

--- a/fern/pages/guides/sending-receiving-email.mdx
+++ b/fern/pages/guides/sending-receiving-email.mdx
@@ -123,6 +123,20 @@ Here's the step-by-step logic for a polling-based conversational agent.
             removeLabels: ["unreplied"],
         });
         ```
+        ```bash title="CLI"
+        # send the reply
+        agentmail inboxes:messages reply \
+          --inbox-id support@agentmail.to \
+          --message-id <message_id> \
+          --text "This is our agent's helpful reply!"
+
+        # update the labels on the original message
+        agentmail inboxes:messages update \
+          --inbox-id support@agentmail.to \
+          --message-id <message_id> \
+          --add-label replied \
+          --remove-label unreplied
+        ```
         </CodeBlocks>
     </Step>
 

--- a/fern/pages/integrations/agent-onboarding.mdx
+++ b/fern/pages/integrations/agent-onboarding.mdx
@@ -179,6 +179,18 @@ await client.inboxes.messages.send(inbox.inboxId, {
 });
 ```
 
+```bash title="CLI"
+# create an inbox
+agentmail inboxes create --display-name "My AI Agent"
+
+# send an email (replace <inbox_id> with the id from above)
+agentmail inboxes:messages send \
+  --inbox-id <inbox_id> \
+  --to user@example.com \
+  --subject "Hello from my AI agent" \
+  --text "Hi! I'm an AI agent with my own email address."
+```
+
 </CodeBlocks>
 
 ### Receive and reply to emails

--- a/fern/pages/resources/security/spam-virus-detection.mdx
+++ b/fern/pages/resources/security/spam-virus-detection.mdx
@@ -31,6 +31,12 @@ threads = client.threads.list(
     include_spam=True,
 )
 ```
+```bash title="CLI"
+# list messages labeled as spam
+agentmail inboxes:messages list \
+  --inbox-id <id> \
+  --label spam
+```
 </CodeBlocks>
 
 Each thread object includes a `spam` label indicating whether it was flagged as spam, so you can handle flagged threads differently in your application logic.

--- a/fern/pages/resources/security/spam-virus-detection.mdx
+++ b/fern/pages/resources/security/spam-virus-detection.mdx
@@ -32,10 +32,10 @@ threads = client.threads.list(
 )
 ```
 ```bash title="CLI"
-# list messages labeled as spam
-agentmail inboxes:messages list \
+# list threads including spam
+agentmail inboxes:threads list \
   --inbox-id <id> \
-  --label spam
+  --include-spam
 ```
 </CodeBlocks>
 

--- a/fern/pages/webhooks/webhook-verification.mdx
+++ b/fern/pages/webhooks/webhook-verification.mdx
@@ -46,6 +46,10 @@ const webhook = await client.webhooks.get("ep_xxx");
 const signingSecret = webhook.secret;
 console.log(`Signing secret: ${signingSecret}`);
 ```
+```bash title="CLI"
+# get webhook details including the signing secret
+agentmail webhooks retrieve --webhook-id ep_xxx
+```
 </CodeBlocks>
 
 <Callout intent="warning" title="Keep your secret safe">

--- a/fern/pages/webhooks/webhooks-overview.mdx
+++ b/fern/pages/webhooks/webhooks-overview.mdx
@@ -53,6 +53,13 @@ The process is straightforward:
             eventTypes: ["message.received", "message.sent"],
         });
         ```
+        ```bash title="CLI"
+        # register a webhook endpoint
+        agentmail webhooks create \
+          --url https://<your-ngrok-url>.ngrok-free.app/webhooks \
+          --event-type message.received \
+          --event-type message.sent
+        ```
         </CodeBlocks>
         Specify which events to receive; omit `event_types` to subscribe to all event types.
     </Step>
@@ -90,6 +97,12 @@ const message = await client.inboxes.messages.get(
 );
 const textBody = message.text;
 const htmlBody = message.html;
+```
+```bash title="CLI"
+# fetch the full message after receiving a webhook
+agentmail inboxes:messages retrieve \
+  --inbox-id <inbox_id> \
+  --message-id <message_id>
 ```
 </CodeBlocks>
 


### PR DESCRIPTION
- Add CLI tabs to CodeBlocks in 16 MDX pages (quickstart, core concepts, guides, webhooks, integrations)
- Add CLI docs blocks to every API reference endpoint definition (23 YAML files)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added CLI examples across docs and API reference so every workflow can be run from the terminal, with clear `agentmail-cli` install steps. Also corrected several examples and flags based on review feedback.

- **New Features**
  - Added CLI tabs to 16 MDX pages (quickstart, core concepts, guides, webhooks, integrations).
  - Added CLI examples to all 23 API reference endpoints via `docs` blocks; standardized groups/flags (e.g., `inboxes:messages`, `--inbox-id`, `--message-id`).
  - Quickstart includes `agentmail-cli` install; examples cover attachments, reply/reply-all/forward, zone-file retrieval, metrics, and thread deletion behavior.

- **Bug Fixes**
  - Use threads list with `--include-spam` in spam/virus detection.
  - Use threads list (not messages list) for label-based filtering.
  - Fix webhooks update flag to `--add-inbox-id`.
  - Align draft scheduling/follow-up timestamps across examples.

<sup>Written for commit 1fc966c52003e923f3865904ac7113ba9849fe96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

