### PR TITLE
Add Update API Key endpoint documentation

### DIFF
--- a/fern/definition/api-keys.yml
+++ b/fern/definition/api-keys.yml
@@ -116,6 +116,9 @@ types:
       api_key_create:
         type: optional<boolean>
         docs: Create API keys.
+      api_key_update:
+        type: optional<boolean>
+        docs: Update API keys.
       api_key_delete:
         type: optional<boolean>
         docs: Delete API keys.
@@ -176,6 +179,11 @@ types:
       name: Name
       permissions: optional<ApiKeyPermissions>
 
+  UpdateApiKeyRequest:
+    properties:
+      name: optional<Name>
+      permissions: optional<ApiKeyPermissions>
+
 service:
   url: Http
   base-path: /api-keys
@@ -201,6 +209,18 @@ service:
       request: CreateApiKeyRequest
       response: CreateApiKeyResponse
       errors:
+        - global.ValidationError
+
+    update:
+      method: PATCH
+      path: /{api_key_id}
+      display-name: Update API Key
+      path-parameters:
+        api_key_id: ApiKeyId
+      request: UpdateApiKeyRequest
+      response: ApiKey
+      errors:
+        - global.NotFoundError
         - global.ValidationError
 
     delete:

--- a/fern/definition/api-keys.yml
+++ b/fern/definition/api-keys.yml
@@ -21,7 +21,13 @@ types:
     docs: Time at which api key was created.
 
   ApiKeyPermissions:
-    docs: Granular permissions for the API key. When ommitted all permissions are granted. Otherwise, only permissions set to true are granted.
+    docs: |
+      Granular permissions for an API key. Each field is an independent
+      boolean grant — only fields set to `true` are granted. A caller cannot
+      grant a permission they do not themselves hold; per-field escalation is
+      rejected with 403. See the `permissions` field on `Create API Key` and
+      `Update API Key` for how `null`, omitted, and populated values are
+      interpreted on each endpoint.
     properties:
       inbox_read:
         type: optional<boolean>
@@ -35,12 +41,6 @@ types:
       inbox_delete:
         type: optional<boolean>
         docs: Delete inboxes.
-      thread_read:
-        type: optional<boolean>
-        docs: Read threads.
-      thread_delete:
-        type: optional<boolean>
-        docs: Delete threads.
       message_read:
         type: optional<boolean>
         docs: Read messages.
@@ -50,6 +50,9 @@ types:
       message_update:
         type: optional<boolean>
         docs: Update message labels.
+      message_delete:
+        type: optional<boolean>
+        docs: Delete messages.
       label_spam_read:
         type: optional<boolean>
         docs: Access messages labeled spam.
@@ -177,12 +180,40 @@ types:
   CreateApiKeyRequest:
     properties:
       name: Name
-      permissions: optional<ApiKeyPermissions>
+      permissions:
+        type: optional<ApiKeyPermissions>
+        docs: |
+          Permissions for the new key. Behavior depends on the value:
+          - Omitted: the new key inherits the creator's permissions
+            (unrestricted creators get an unrestricted child; restricted
+            creators get a child with their own granular permissions).
+          - `null`: makes the new key unrestricted. Only allowed when the
+            creator is themselves unrestricted; restricted creators sending
+            `null` get a 403.
+          - Populated object: grants the listed `true` fields, intersected
+            with the creator's own permissions. Per-field escalation
+            (granting a permission the creator doesn't hold) is rejected
+            with 403.
 
   UpdateApiKeyRequest:
+    docs: At least one of `name` or `permissions` must be provided.
     properties:
       name: optional<Name>
-      permissions: optional<ApiKeyPermissions>
+      permissions:
+        type: optional<ApiKeyPermissions>
+        docs: |
+          Permissions to apply. Behavior depends on the value:
+          - Omitted: the key's permissions are unchanged.
+          - `null`: clears all restrictions and makes the key unrestricted.
+            Only allowed when the caller is themselves unrestricted;
+            restricted callers sending `null` get a 403. The same gate
+            applies when the target key is currently unrestricted and the
+            caller tries to make it restricted — only unrestricted callers
+            can flip a key between restricted and unrestricted.
+          - Populated object: merged with the stored permissions — fields
+            not mentioned are preserved, mentioned fields overwrite.
+            Per-field escalation (granting a permission the caller doesn't
+            hold) is rejected with 403.
 
 service:
   url: Http
@@ -210,6 +241,7 @@ service:
       response: CreateApiKeyResponse
       errors:
         - global.ValidationError
+        - ForbiddenError
 
     update:
       method: PATCH
@@ -222,6 +254,7 @@ service:
       errors:
         - global.NotFoundError
         - global.ValidationError
+        - ForbiddenError
 
     delete:
       method: DELETE
@@ -231,3 +264,8 @@ service:
         api_key_id: ApiKeyId
       errors:
         - global.NotFoundError
+
+errors:
+  ForbiddenError:
+    status-code: 403
+    type: global.ErrorResponse

--- a/fern/definition/inboxes/api-keys.yml
+++ b/fern/definition/inboxes/api-keys.yml
@@ -36,6 +36,18 @@ service:
         - global.NotFoundError
         - global.ValidationError
 
+    update:
+      method: PATCH
+      path: /{api_key_id}
+      display-name: Update API Key
+      path-parameters:
+        api_key_id: api-keys.ApiKeyId
+      request: api-keys.UpdateApiKeyRequest
+      response: api-keys.ApiKey
+      errors:
+        - global.NotFoundError
+        - global.ValidationError
+
     delete:
       method: DELETE
       path: /{api_key_id}

--- a/fern/definition/pods/api-keys.yml
+++ b/fern/definition/pods/api-keys.yml
@@ -36,6 +36,18 @@ service:
         - global.NotFoundError
         - global.ValidationError
 
+    update:
+      method: PATCH
+      path: /{api_key_id}
+      display-name: Update API Key
+      path-parameters:
+        api_key_id: api-keys.ApiKeyId
+      request: api-keys.UpdateApiKeyRequest
+      response: api-keys.ApiKey
+      errors:
+        - global.NotFoundError
+        - global.ValidationError
+
     delete:
       method: DELETE
       path: /{api_key_id}


### PR DESCRIPTION
Documents the merged Update API Key endpoint and syncs the existing definition to the current API surface.

## What changed in this PR

- **Permission list synced with code**: added `message_delete`; removed `thread_read` and `thread_delete` (these were replaced by `message_*` permissions in the API back in March/April but the docs lagged).
- **Update endpoint documented** with explicit semantics for the `permissions` field (omit / `null` / populated object).
- **Create endpoint** docstring clarified along the same lines for consistency.
- **`ForbiddenError` (403)** added to Create and Update — surfaces when a caller tries to clear permissions or grant fields they don't themselves hold.
- **"At least one of `name` or `permissions`"** note added on Update.

## A note on `null` in the TypeScript SDK

The API accepts `permissions: null` to clear restrictions and make a key unrestricted. This is reflected in the docstring on the field. Two relevant facts about how the SDKs render this:

- **Python SDK**: native — `permissions=None` works idiomatically because Fern emits `typing.Optional[ApiKeyPermissions]` (which is `T | None`).
- **TypeScript SDK**: the generated type is `permissions?: ApiKeyPermissions` (i.e. `T | undefined`). Fern's YAML grammar doesn't express "nullable" — `optional<T>` is the closest construct, and it doesn't include `null` in the resulting TS type.

Net effect for TS users wanting to clear permissions: the runtime sends `null` correctly when given `null`, but the compiler will complain unless they cast (`{ permissions: null as any }`). The docstring on the field tells them what to send, so this is a typing limitation, not a behavior limitation. Same shape as every other update endpoint in the SDK; not unique to this PR.

If we later want first-class TS ergonomics on the clear path, the cleanest fix is an API change (replace the `null` semantic with a sentinel field like `clear_permissions: true`). That's out of scope here.

## Test plan

- [x] `npx fern-api check` — all checks pass.
- [x] Permission list verified 1:1 against `permissionShape` in `src/schemas/api-key.ts`.
- [x] Errors verified against handler throws (`ForbiddenError`, `NotFoundError`, `ValidationError`).
- [x] Permission semantics docstring traced branch-by-branch against `resolveCreateApiKeyPermissions` and `resolveUpdateApiKeyPermissions`.
- [ ] Fern CI generates updated TS + Python SDKs on merge.