### PR TITLE
[ENG-422] Agent signup docs issue

### DIFF
--- a/fern/definition/agent.yml
+++ b/fern/definition/agent.yml
@@ -52,7 +52,9 @@ service:
       path: /sign-up
       display-name: Sign Up
       docs: |
-        Create a new agent organization with an inbox and API key. A 6-digit OTP is sent to the human's email for verification.
+        Create a new agent organization with an inbox and API key. This endpoint is for signing up for the first time. If you've already signed up, you're all set — just use your existing API key.
+
+        A 6-digit OTP is sent to the human's email for verification.
 
         This endpoint is idempotent. Calling it again with the same `human_email` will rotate the API key and resend the OTP if expired.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarifies the Sign Up endpoint docs to say it’s for first-time signup only; if you’ve already signed up, use your existing API key. Addresses ENG-422 by reducing confusion while keeping OTP and idempotency notes unchanged.

<sup>Written for commit fb91bb94623763ed82f8ced5ec8c8b5c9a45a519. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

