### PR TITLE
adding delete message api

### DIFF
--- a/fern/definition/inboxes/messages.yml
+++ b/fern/definition/inboxes/messages.yml
@@ -102,6 +102,22 @@ service:
         - global.ValidationError
         - global.NotFoundError
 
+    delete:
+      method: DELETE
+      path: /{message_id}
+      display-name: Delete Message
+      docs: |
+        Permanently deletes a message.
+
+        **CLI:**
+        ```bash
+        agentmail inboxes:messages delete --inbox-id <inbox_id> --message-id <message_id>
+        ```
+      path-parameters:
+        message_id: messages.MessageId
+      errors:
+        - global.NotFoundError
+
     send:
       method: POST
       path: /send


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Delete Message API to permanently remove a message by ID from an inbox. Also documents CLI usage for quick deletes.

- **New Features**
  - Adds `DELETE /{message_id}` endpoint to delete a message.
  - Accepts `message_id` (`messages.MessageId`); returns `global.NotFoundError` if not found.
  - CLI: `agentmail inboxes:messages delete --inbox-id <inbox_id> --message-id <message_id>`.

<sup>Written for commit 3a5668fabc06947752a888dd34f6488ff520966b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

