### PR TITLE
adding spam/block event type to webscoket and webhook

### DIFF
--- a/fern/definition/events.yml
+++ b/fern/definition/events.yml
@@ -11,6 +11,10 @@ types:
     enum:
       - name: MESSAGE_RECEIVED
         value: message.received
+      - name: MESSAGE_RECEIVED_SPAM
+        value: message.received.spam
+      - name: MESSAGE_RECEIVED_BLOCKED
+        value: message.received.blocked
       - name: MESSAGE_SENT
         value: message.sent
       - name: MESSAGE_DELIVERED
@@ -119,6 +123,24 @@ types:
     properties:
       type: literal<"event">
       event_type: literal<"message.received">
+      event_id: EventId
+      message: messages.Message
+      thread: threads.ThreadItem
+
+  MessageReceivedSpamEvent:
+    docs: A message was received and classified as spam. Requires `label_spam_read` permission.
+    properties:
+      type: literal<"event">
+      event_type: literal<"message.received.spam">
+      event_id: EventId
+      message: messages.Message
+      thread: threads.ThreadItem
+
+  MessageReceivedBlockedEvent:
+    docs: A message was received and matched a block list entry. Requires `label_blocked_read` permission.
+    properties:
+      type: literal<"event">
+      event_type: literal<"message.received.blocked">
       event_id: EventId
       message: messages.Message
       thread: threads.ThreadItem

--- a/fern/definition/webhooks/__package__.yml
+++ b/fern/definition/webhooks/__package__.yml
@@ -1,3 +1,4 @@
+
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
 
 imports:

--- a/fern/definition/websockets.yml
+++ b/fern/definition/websockets.yml
@@ -44,6 +44,12 @@ channel:
     message_received:
       origin: server
       body: events.MessageReceivedEvent
+    message_received_spam:
+      origin: server
+      body: events.MessageReceivedSpamEvent
+    message_received_blocked:
+      origin: server
+      body: events.MessageReceivedBlockedEvent
     message_sent:
       origin: server
       body: events.MessageSentEvent

--- a/fern/pages/core-concepts/permissions.mdx
+++ b/fern/pages/core-concepts/permissions.mdx
@@ -70,6 +70,10 @@ A restricted API key cannot create a child key with more permissions than itself
   When a label visibility permission is denied, items with that label are automatically excluded from list results and return "not found" on direct access. For example, setting `label_spam_read` to `false` means the key will never see spam messages in any listing or lookup.
 </Info>
 
+<Callout intent="info" title="Event subscriptions">
+  Label visibility permissions also control whether an API key can subscribe to the corresponding event types on [webhooks](/events) and [WebSockets](/websockets). An API key without `label_spam_read` cannot create a webhook or WebSocket subscription for `message.received.spam` events, and an API key without `label_blocked_read` cannot subscribe to `message.received.blocked` events.
+</Callout>
+
 ### Drafts
 
 | Permission | Description |

--- a/fern/pages/webhooks/webhooks-events.mdx
+++ b/fern/pages/webhooks/webhooks-events.mdx
@@ -50,10 +50,10 @@ async function handleWebhook(payload: Record<string, unknown>) {
     const event = await serialization.events.MessageRejectedEvent.parse(payload);
     console.log(event.reject.reason);
   } else if (eventType === "message.received.spam") {
-    const event = await serialization.events.MessageReceivedEvent.parse(payload);
+    const event = await serialization.events.MessageReceivedSpamEvent.parse(payload);
     console.log(event.message.subject);
   } else if (eventType === "message.received.blocked") {
-    const event = await serialization.events.MessageReceivedEvent.parse(payload);
+    const event = await serialization.events.MessageReceivedBlockedEvent.parse(payload);
     console.log(event.message.subject);
   } else if (eventType === "domain.verified") {
     const event = await serialization.events.DomainVerifiedEvent.parse(payload);
@@ -64,6 +64,8 @@ async function handleWebhook(payload: Record<string, unknown>) {
 ```python title="Python"
 from agentmail import (
     MessageReceivedEvent,
+    MessageReceivedSpamEvent,
+    MessageReceivedBlockedEvent,
     MessageSentEvent,
     MessageBouncedEvent,
     MessageDeliveredEvent,
@@ -96,10 +98,10 @@ def handle_webhook(payload: dict):
         event = MessageRejectedEvent(**payload)
         print(event.reject.reason)
     elif event_type == "message.received.spam":
-        event = MessageReceivedEvent(**payload)
+        event = MessageReceivedSpamEvent(**payload)
         print(event.message.subject)
     elif event_type == "message.received.blocked":
-        event = MessageReceivedEvent(**payload)
+        event = MessageReceivedBlockedEvent(**payload)
         print(event.message.subject)
     elif event_type == "domain.verified":
         event = DomainVerifiedEvent(**payload)
@@ -116,14 +118,15 @@ Copy one of the blocks below into Cursor or Claude for webhook event parsing in 
   """
   AgentMail Webhook Events — copy into Cursor/Claude.
 
-  Parse typed events: MessageReceivedEvent (has message+thread, used for message.received, message.received.spam, message.received.blocked),
+  Parse typed events: MessageReceivedEvent (message.received), MessageReceivedSpamEvent (message.received.spam), MessageReceivedBlockedEvent (message.received.blocked),
   MessageSentEvent (send), MessageBouncedEvent (bounce), MessageDeliveredEvent (delivery), MessageComplainedEvent (complaint),
   MessageRejectedEvent (reject), DomainVerifiedEvent (domain).
   Only message.received* includes full message+thread; others have send/delivery/bounce/complaint/reject/domain.
   Note: message.received.spam and message.received.blocked require label_spam_read / label_blocked_read permissions.
   """
   from agentmail import (
-    MessageReceivedEvent, MessageSentEvent, MessageBouncedEvent,
+    MessageReceivedEvent, MessageReceivedSpamEvent, MessageReceivedBlockedEvent,
+    MessageSentEvent, MessageBouncedEvent,
     MessageDeliveredEvent, MessageComplainedEvent, MessageRejectedEvent, DomainVerifiedEvent,
   )
 
@@ -135,8 +138,8 @@ Copy one of the blocks below into Cursor or Claude for webhook event parsing in 
     elif t == "message.delivered": e = MessageDeliveredEvent(**payload)
     elif t == "message.complained": e = MessageComplainedEvent(**payload)
     elif t == "message.rejected": e = MessageRejectedEvent(**payload); print(e.reject.reason)
-    elif t == "message.received.spam": e = MessageReceivedEvent(**payload); print(e.message.subject)
-    elif t == "message.received.blocked": e = MessageReceivedEvent(**payload); print(e.message.subject)
+    elif t == "message.received.spam": e = MessageReceivedSpamEvent(**payload); print(e.message.subject)
+    elif t == "message.received.blocked": e = MessageReceivedBlockedEvent(**payload); print(e.message.subject)
     elif t == "domain.verified": e = DomainVerifiedEvent(**payload); print(e.domain.status)
   ```
 
@@ -144,7 +147,8 @@ Copy one of the blocks below into Cursor or Claude for webhook event parsing in 
   /**
    * AgentMail Webhook Events — copy into Cursor/Claude.
    *
-   * Parse with serialization.events.MessageReceivedEvent.parse(payload), etc.
+   * Parse with serialization.events.<EventType>.parse(payload).
+   * message.received → MessageReceivedEvent, message.received.spam → MessageReceivedSpamEvent, message.received.blocked → MessageReceivedBlockedEvent.
    * Only message.received* has message+thread; others have send/delivery/bounce/complaint/reject/domain.
    * message.received.spam and message.received.blocked require label_spam_read / label_blocked_read permissions.
    */
@@ -171,10 +175,10 @@ Copy one of the blocks below into Cursor or Claude for webhook event parsing in 
       const e = await serialization.events.MessageRejectedEvent.parse(payload);
       console.log(e.reject);
     } else if (t === "message.received.spam") {
-      const e = await serialization.events.MessageReceivedEvent.parse(payload);
+      const e = await serialization.events.MessageReceivedSpamEvent.parse(payload);
       console.log(e.message.subject);
     } else if (t === "message.received.blocked") {
-      const e = await serialization.events.MessageReceivedEvent.parse(payload);
+      const e = await serialization.events.MessageReceivedBlockedEvent.parse(payload);
       console.log(e.message.subject);
     } else if (t === "domain.verified") {
       const e = await serialization.events.DomainVerifiedEvent.parse(payload);

--- a/fern/pages/webhooks/webhooks-events.mdx
+++ b/fern/pages/webhooks/webhooks-events.mdx
@@ -49,6 +49,12 @@ async function handleWebhook(payload: Record<string, unknown>) {
   } else if (eventType === "message.rejected") {
     const event = await serialization.events.MessageRejectedEvent.parse(payload);
     console.log(event.reject.reason);
+  } else if (eventType === "message.received.spam") {
+    const event = await serialization.events.MessageReceivedEvent.parse(payload);
+    console.log(event.message.subject);
+  } else if (eventType === "message.received.blocked") {
+    const event = await serialization.events.MessageReceivedEvent.parse(payload);
+    console.log(event.message.subject);
   } else if (eventType === "domain.verified") {
     const event = await serialization.events.DomainVerifiedEvent.parse(payload);
     console.log(event.domain.status);
@@ -89,6 +95,12 @@ def handle_webhook(payload: dict):
     elif event_type == "message.rejected":
         event = MessageRejectedEvent(**payload)
         print(event.reject.reason)
+    elif event_type == "message.received.spam":
+        event = MessageReceivedEvent(**payload)
+        print(event.message.subject)
+    elif event_type == "message.received.blocked":
+        event = MessageReceivedEvent(**payload)
+        print(event.message.subject)
     elif event_type == "domain.verified":
         event = DomainVerifiedEvent(**payload)
         print(event.domain.status)
@@ -104,9 +116,11 @@ Copy one of the blocks below into Cursor or Claude for webhook event parsing in 
   """
   AgentMail Webhook Events — copy into Cursor/Claude.
 
-  Parse typed events: MessageReceivedEvent (has message+thread), MessageSentEvent (send), MessageBouncedEvent (bounce),
-  MessageDeliveredEvent (delivery), MessageComplainedEvent (complaint), MessageRejectedEvent (reject), DomainVerifiedEvent (domain).
-  Only message.received includes full message+thread; others have send/delivery/bounce/complaint/reject/domain.
+  Parse typed events: MessageReceivedEvent (has message+thread, used for message.received, message.received.spam, message.received.blocked),
+  MessageSentEvent (send), MessageBouncedEvent (bounce), MessageDeliveredEvent (delivery), MessageComplainedEvent (complaint),
+  MessageRejectedEvent (reject), DomainVerifiedEvent (domain).
+  Only message.received* includes full message+thread; others have send/delivery/bounce/complaint/reject/domain.
+  Note: message.received.spam and message.received.blocked require label_spam_read / label_blocked_read permissions.
   """
   from agentmail import (
     MessageReceivedEvent, MessageSentEvent, MessageBouncedEvent,
@@ -121,6 +135,8 @@ Copy one of the blocks below into Cursor or Claude for webhook event parsing in 
     elif t == "message.delivered": e = MessageDeliveredEvent(**payload)
     elif t == "message.complained": e = MessageComplainedEvent(**payload)
     elif t == "message.rejected": e = MessageRejectedEvent(**payload); print(e.reject.reason)
+    elif t == "message.received.spam": e = MessageReceivedEvent(**payload); print(e.message.subject)
+    elif t == "message.received.blocked": e = MessageReceivedEvent(**payload); print(e.message.subject)
     elif t == "domain.verified": e = DomainVerifiedEvent(**payload); print(e.domain.status)
   ```
 
@@ -129,7 +145,8 @@ Copy one of the blocks below into Cursor or Claude for webhook event parsing in 
    * AgentMail Webhook Events — copy into Cursor/Claude.
    *
    * Parse with serialization.events.MessageReceivedEvent.parse(payload), etc.
-   * Only message.received has message+thread; others have send/delivery/bounce/complaint/reject/domain.
+   * Only message.received* has message+thread; others have send/delivery/bounce/complaint/reject/domain.
+   * message.received.spam and message.received.blocked require label_spam_read / label_blocked_read permissions.
    */
   import { serialization } from "agentmail";
 
@@ -153,6 +170,12 @@ Copy one of the blocks below into Cursor or Claude for webhook event parsing in 
     } else if (t === "message.rejected") {
       const e = await serialization.events.MessageRejectedEvent.parse(payload);
       console.log(e.reject);
+    } else if (t === "message.received.spam") {
+      const e = await serialization.events.MessageReceivedEvent.parse(payload);
+      console.log(e.message.subject);
+    } else if (t === "message.received.blocked") {
+      const e = await serialization.events.MessageReceivedEvent.parse(payload);
+      console.log(e.message.subject);
     } else if (t === "domain.verified") {
       const e = await serialization.events.DomainVerifiedEvent.parse(payload);
       console.log(e.domain);
@@ -216,6 +239,106 @@ Copy one of the blocks below into Cursor or Claude for webhook event parsing in 
     "last_message_id": "<abc123@agentmail.to>",
     "message_count": 1,
     "size": 2048,
+    "updated_at": "2023-10-27T10:00:00Z",
+    "created_at": "2023-10-27T10:00:00Z"
+  }
+}
+```
+</CodeGroup>
+
+### `message.received.spam`
+
+- **Description:** Triggered when a new email is received and classified as spam. The payload structure is the same as `message.received`. Messages classified as spam are not delivered as `message.received` events.
+- **Example use-case:** Route spam to a review queue or log spam patterns for analysis.
+
+<Callout intent="warn">
+  This event is only delivered if the API key used to create the webhook has the `label_spam_read` permission. Without this permission, the webhook creation will be rejected with a `403 Forbidden` error.
+</Callout>
+
+<CodeGroup>
+```json
+{
+  "type": "event",
+  "event_type": "message.received.spam",
+  "event_id": "evt_spam123",
+  "message": {
+    "inbox_id": "inbox_456def",
+    "thread_id": "thd_789ghi",
+    "message_id": "<spam123@example.com>",
+    "labels": ["spam"],
+    "timestamp": "2023-10-27T10:00:00Z",
+    "from": "spammer@example.com",
+    "to": ["agent@agentmail.to"],
+    "subject": "Suspicious offer",
+    "preview": "You've been selected...",
+    "text": "Full spam message body.",
+    "html": "<html>...</html>",
+    "size": 1024,
+    "updated_at": "2023-10-27T10:00:00Z",
+    "created_at": "2023-10-27T10:00:00Z"
+  },
+  "thread": {
+    "inbox_id": "inbox_456def",
+    "thread_id": "thd_789ghi",
+    "labels": ["spam"],
+    "timestamp": "2023-10-27T10:00:00Z",
+    "senders": ["spammer@example.com"],
+    "recipients": ["agent@agentmail.to"],
+    "subject": "Suspicious offer",
+    "preview": "You've been selected...",
+    "last_message_id": "<spam123@example.com>",
+    "message_count": 1,
+    "size": 1024,
+    "updated_at": "2023-10-27T10:00:00Z",
+    "created_at": "2023-10-27T10:00:00Z"
+  }
+}
+```
+</CodeGroup>
+
+### `message.received.blocked`
+
+- **Description:** Triggered when a new email is received and matched a block list entry. The payload structure is the same as `message.received`. Messages that match a block list are not delivered as `message.received` events.
+- **Example use-case:** Audit blocked senders or maintain a log of blocked messages.
+
+<Callout intent="warn">
+  This event is only delivered if the API key used to create the webhook has the `label_blocked_read` permission. Without this permission, the webhook creation will be rejected with a `403 Forbidden` error.
+</Callout>
+
+<CodeGroup>
+```json
+{
+  "type": "event",
+  "event_type": "message.received.blocked",
+  "event_id": "evt_blocked456",
+  "message": {
+    "inbox_id": "inbox_456def",
+    "thread_id": "thd_789ghi",
+    "message_id": "<blocked456@example.com>",
+    "labels": ["blocked"],
+    "timestamp": "2023-10-27T10:00:00Z",
+    "from": "blocked-sender@example.com",
+    "to": ["agent@agentmail.to"],
+    "subject": "Blocked message",
+    "preview": "This message was blocked...",
+    "text": "Full blocked message body.",
+    "html": "<html>...</html>",
+    "size": 512,
+    "updated_at": "2023-10-27T10:00:00Z",
+    "created_at": "2023-10-27T10:00:00Z"
+  },
+  "thread": {
+    "inbox_id": "inbox_456def",
+    "thread_id": "thd_789ghi",
+    "labels": ["blocked"],
+    "timestamp": "2023-10-27T10:00:00Z",
+    "senders": ["blocked-sender@example.com"],
+    "recipients": ["agent@agentmail.to"],
+    "subject": "Blocked message",
+    "preview": "This message was blocked...",
+    "last_message_id": "<blocked456@example.com>",
+    "message_count": 1,
+    "size": 512,
     "updated_at": "2023-10-27T10:00:00Z",
     "created_at": "2023-10-27T10:00:00Z"
   }
@@ -411,5 +534,9 @@ When creating a webhook, you can specify which events to subscribe to. This allo
 - Create specialized webhooks for specific workflows
 
 For example, if you only need to trigger workflows on incoming messages, you can subscribe to just `message.received`. If you're building a delivery tracking system, you might subscribe to `message.sent`, `message.delivered`, and `message.bounced`.
+
+<Callout intent="info">
+  By default, spam and blocked events are **not** delivered. To receive them, you must explicitly include `message.received.spam` or `message.received.blocked` in the `event_types` list when creating your webhook. The API key must also have the corresponding `label_spam_read` or `label_blocked_read` permission.
+</Callout>
 
 If you have any specific webhook notifications you would like, please ping us in the `#feature-requests` channel in the [Discord](https://discord.gg/hTYatWYWBc)

--- a/fern/pages/webhooks/webhooks-overview.mdx
+++ b/fern/pages/webhooks/webhooks-overview.mdx
@@ -16,10 +16,12 @@ This event-driven approach is more efficient and allows you to build fast, respo
 
 ## Available Events
 
-AgentMail supports seven webhook event types. When creating a webhook, you can subscribe to specific events or receive all of them. See [Webhook Events](/events) for full payload details.
+AgentMail supports nine webhook event types. When creating a webhook, you can subscribe to specific events or receive all of them. See [Webhook Events](/events) for full payload details.
 
 **Message events:**
 - **`message.received`** — New email received and processed in one of your inboxes
+- **`message.received.spam`** — A message was received and classified as spam (requires `label_spam_read` permission)
+- **`message.received.blocked`** — A message was received and matched a block list entry (requires `label_blocked_read` permission)
 - **`message.sent`** — Message successfully sent from your inbox
 - **`message.delivered`** — Delivery confirmed by the recipient's mail server
 - **`message.bounced`** — Message failed to deliver and bounced back
@@ -28,6 +30,10 @@ AgentMail supports seven webhook event types. When creating a webhook, you can s
 
 **Domain events:**
 - **`domain.verified`** — Custom domain successfully verified
+
+<Callout intent="info">
+  Spam and blocked events are excluded by default. To receive them, explicitly include `message.received.spam` or `message.received.blocked` in the `event_types` list when creating a webhook. Messages with these labels are no longer sent as `message.received`.
+</Callout>
 
 ## The Webhook Workflow
 
@@ -180,7 +186,7 @@ Copy one of the blocks below into Cursor or Claude for complete Webhooks API kno
   - webhooks.update(webhook_id, add_inbox_ids?, remove_inbox_ids?, add_pod_ids?, remove_pod_ids?)
   - webhooks.delete(webhook_id)
 
-  Events: message.received, message.sent, message.delivered, message.bounced, message.complained, message.rejected, domain.verified
+  Events: message.received, message.received.spam, message.received.blocked, message.sent, message.delivered, message.bounced, message.complained, message.rejected, domain.verified
   Payload: event_type, event_id, plus message/send/delivery/bounce/complaint/reject/domain. Verify with Svix (webhook.secret).
   """
   import os
@@ -208,7 +214,7 @@ Copy one of the blocks below into Cursor or Claude for complete Webhooks API kno
    * - webhooks.update(webhookId, { addInboxIds?, removeInboxIds?, addPodIds?, removePodIds? })
    * - webhooks.delete(webhookId)
    *
-   * Events: message.received, message.sent, message.delivered, message.bounced, message.complained, message.rejected, domain.verified
+   * Events: message.received, message.received.spam, message.received.blocked, message.sent, message.delivered, message.bounced, message.complained, message.rejected, domain.verified
    * Verify with Svix using webhook.secret. Use express.raw() for body—signature needs raw payload.
    */
   import { AgentMailClient } from "agentmail";

--- a/fern/pages/webhooks/webhooks-overview.mdx
+++ b/fern/pages/webhooks/webhooks-overview.mdx
@@ -67,7 +67,7 @@ The process is straightforward:
           --event-type message.sent
         ```
         </CodeBlocks>
-        Specify which events to receive; omit `event_types` to subscribe to all event types.
+        Specify which events to receive; omit `event_types` to subscribe to all standard event types. Spam and blocked events must always be explicitly included.
     </Step>
     <Step title="3. AgentMail Sends Events">
         When an event occurs (e.g. a new message is received, a message is delivered, or a domain is verified), AgentMail sends a `POST` request with a JSON payload to your registered URL.

--- a/fern/pages/webhooks/webhooks-overview.mdx
+++ b/fern/pages/webhooks/webhooks-overview.mdx
@@ -188,6 +188,7 @@ Copy one of the blocks below into Cursor or Claude for complete Webhooks API kno
 
   Events: message.received, message.received.spam, message.received.blocked, message.sent, message.delivered, message.bounced, message.complained, message.rejected, domain.verified
   Payload: event_type, event_id, plus message/send/delivery/bounce/complaint/reject/domain. Verify with Svix (webhook.secret).
+  Note: message.received.spam and message.received.blocked are excluded by default. To receive them, explicitly include them in event_types and ensure the API key has label_spam_read / label_blocked_read permissions.
   """
   import os
   from dotenv import load_dotenv
@@ -215,6 +216,7 @@ Copy one of the blocks below into Cursor or Claude for complete Webhooks API kno
    * - webhooks.delete(webhookId)
    *
    * Events: message.received, message.received.spam, message.received.blocked, message.sent, message.delivered, message.bounced, message.complained, message.rejected, domain.verified
+   * Note: message.received.spam and message.received.blocked are excluded by default. To receive them, explicitly include them in eventTypes and ensure the API key has label_spam_read / label_blocked_read permissions.
    * Verify with Svix using webhook.secret. Use express.raw() for body—signature needs raw payload.
    */
   import { AgentMailClient } from "agentmail";

--- a/fern/pages/websockets.mdx
+++ b/fern/pages/websockets.mdx
@@ -286,8 +286,8 @@ socket.sendSubscribe({
 | Event | Python | TypeScript | Description |
 |-------|--------|------------|-------------|
 | `message_received` | `MessageReceivedEvent` | `AgentMail.MessageReceivedEvent` | New email received |
-| `message_received_spam` | `MessageReceivedEvent` | `AgentMail.MessageReceivedEvent` | Email received, classified as spam |
-| `message_received_blocked` | `MessageReceivedEvent` | `AgentMail.MessageReceivedEvent` | Email received, matched a block list entry |
+| `message_received_spam` | `MessageReceivedSpamEvent` | `AgentMail.MessageReceivedSpamEvent` | Email received, classified as spam |
+| `message_received_blocked` | `MessageReceivedBlockedEvent` | `AgentMail.MessageReceivedBlockedEvent` | Email received, matched a block list entry |
 | `message_sent` | `MessageSentEvent` | `AgentMail.MessageSentEvent` | Email was sent |
 | `message_delivered` | `MessageDeliveredEvent` | `AgentMail.MessageDeliveredEvent` | Email was delivered |
 | `message_bounced` | `MessageBouncedEvent` | `AgentMail.MessageBouncedEvent` | Email bounced |
@@ -402,7 +402,7 @@ Copy one of the blocks below into Cursor or Claude for WebSockets in one shot.
   Sync: with client.websockets.connect() as socket: socket.send_subscribe(Subscribe(inbox_ids=[...])); for event in socket: ...
   Async: async with client.websockets.connect() as socket: await socket.send_subscribe(...); async for event in socket: ...
   Subscribe(inbox_ids=[...], pod_ids=[...], event_types=[...])
-  Event types: Subscribed, MessageReceivedEvent (also for message.received.spam/blocked), MessageSentEvent, MessageDeliveredEvent, MessageBouncedEvent, MessageComplainedEvent, MessageRejectedEvent, DomainVerifiedEvent
+  Event types: Subscribed, MessageReceivedEvent, MessageReceivedSpamEvent, MessageReceivedBlockedEvent, MessageSentEvent, MessageDeliveredEvent, MessageBouncedEvent, MessageComplainedEvent, MessageRejectedEvent, DomainVerifiedEvent
   Spam/blocked events require explicit opt-in via event_types and label_spam_read / label_blocked_read permissions.
   """
   from agentmail import AgentMail, Subscribe, Subscribed, MessageReceivedEvent

--- a/fern/pages/websockets.mdx
+++ b/fern/pages/websockets.mdx
@@ -230,6 +230,12 @@ Subscribe(
     inbox_ids=["agent@agentmail.to"],
     event_types=["message.received", "message.sent"]
 )
+
+# Subscribe to spam and blocked events (requires label_spam_read / label_blocked_read permissions)
+Subscribe(
+    inbox_ids=["agent@agentmail.to"],
+    event_types=["message.received", "message.received.spam", "message.received.blocked"]
+)
 ```
 
 **TypeScript:**
@@ -252,7 +258,18 @@ socket.sendSubscribe({
   inboxIds: ["agent@agentmail.to"],
   eventTypes: ["message.received", "message.sent"],
 });
+
+// Subscribe to spam and blocked events (requires label_spam_read / label_blocked_read permissions)
+socket.sendSubscribe({
+  type: "subscribe",
+  inboxIds: ["agent@agentmail.to"],
+  eventTypes: ["message.received", "message.received.spam", "message.received.blocked"],
+});
 ```
+
+<Callout intent="info">
+  By default (when no `event_types` are specified), spam and blocked events are excluded from the subscription. To receive spam events, explicitly include `message.received.spam` in `event_types` and ensure the API key has the `label_spam_read` permission. The same applies to `message.received.blocked` with the `label_blocked_read` permission.
+</Callout>
 
 ---
 
@@ -269,6 +286,8 @@ socket.sendSubscribe({
 | Event | Python | TypeScript | Description |
 |-------|--------|------------|-------------|
 | `message_received` | `MessageReceivedEvent` | `AgentMail.MessageReceivedEvent` | New email received |
+| `message_received_spam` | `MessageReceivedEvent` | `AgentMail.MessageReceivedEvent` | Email received, classified as spam |
+| `message_received_blocked` | `MessageReceivedEvent` | `AgentMail.MessageReceivedEvent` | Email received, matched a block list entry |
 | `message_sent` | `MessageSentEvent` | `AgentMail.MessageSentEvent` | Email was sent |
 | `message_delivered` | `MessageDeliveredEvent` | `AgentMail.MessageDeliveredEvent` | Email was delivered |
 | `message_bounced` | `MessageBouncedEvent` | `AgentMail.MessageBouncedEvent` | Email bounced |
@@ -383,7 +402,8 @@ Copy one of the blocks below into Cursor or Claude for WebSockets in one shot.
   Sync: with client.websockets.connect() as socket: socket.send_subscribe(Subscribe(inbox_ids=[...])); for event in socket: ...
   Async: async with client.websockets.connect() as socket: await socket.send_subscribe(...); async for event in socket: ...
   Subscribe(inbox_ids=[...], pod_ids=[...], event_types=[...])
-  Event types: Subscribed, MessageReceivedEvent, MessageSentEvent, MessageDeliveredEvent, MessageBouncedEvent, MessageComplainedEvent, MessageRejectedEvent, DomainVerifiedEvent
+  Event types: Subscribed, MessageReceivedEvent (also for message.received.spam/blocked), MessageSentEvent, MessageDeliveredEvent, MessageBouncedEvent, MessageComplainedEvent, MessageRejectedEvent, DomainVerifiedEvent
+  Spam/blocked events require explicit opt-in via event_types and label_spam_read / label_blocked_read permissions.
   """
   from agentmail import AgentMail, Subscribe, Subscribed, MessageReceivedEvent
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add spam and blocked message event types to webhooks and WebSockets so apps can handle filtered inbound mail explicitly. These events are opt-in and gated by label permissions.

- **New Features**
  - Added `message.received.spam` and `message.received.blocked` to `events.yml`; payloads match `message.received`.
  - WebSocket channel now emits `message_received_spam` and `message_received_blocked`.
  - Docs updated: Python/TypeScript parsing examples, event tables now show nine events, and clear permission/opt-in callouts for spam/blocked on webhooks and WebSockets.
  - Messages labeled spam/blocked no longer fire `message.received`.

- **Migration**
  - To receive these, include `message.received.spam` and/or `message.received.blocked` in webhook/WebSocket `event_types`. Omitting `event_types` subscribes to standard events only.
  - API keys must have `label_spam_read` or `label_blocked_read`; keys without them cannot subscribe and will get 403 on creation.
  - Update handlers that relied on spam/blocked via `message.received` to listen to the new event types.

<sup>Written for commit b0f389616863fd6aef46d5473dad958ee40b0b84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

