### PR TITLE
Event log api

### DIFF
--- a/fern/definition/inbox-events.yml
+++ b/fern/definition/inbox-events.yml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
+
+imports:
+  global: __package__.yml
+  inboxes: inboxes/__package__.yml
+
+types:
+  InboxEventId:
+    type: string
+    docs: ID of event.
+
+  InboxEventType:
+    enum:
+      - name: LABEL_ADDED
+        value: label_added
+      - name: LABEL_REMOVED
+        value: label_removed
+    docs: Type of inbox event.
+
+  InboxEvent:
+    properties:
+      organization_id: global.OrganizationId
+      pod_id:
+        type: string
+        docs: ID of pod.
+      inbox_id: inboxes.InboxId
+      event_id: InboxEventId
+      event_type: InboxEventType
+      message_id:
+        type: string
+        docs: ID of message.
+      label:
+        type: string
+        docs: Label added or removed.
+      event_at:
+        type: datetime
+        docs: Time at which the event occurred.
+      created_at:
+        type: datetime
+        docs: Time at which the event was recorded.
+
+  ListInboxEventsResponse:
+    properties:
+      count: global.Count
+      limit: optional<global.Limit>
+      next_page_token: optional<global.PageToken>
+      events:
+        type: list<InboxEvent>
+        docs: Ordered by `event_id` descending.

--- a/fern/definition/inboxes/__package__.yml
+++ b/fern/definition/inboxes/__package__.yml
@@ -6,6 +6,7 @@ navigation:
   - drafts.yml
   - lists.yml
   - metrics.yml
+  - events.yml
   - api-keys.yml
 
 imports:

--- a/fern/definition/inboxes/events.yml
+++ b/fern/definition/inboxes/events.yml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
+
+imports:
+  global: ../__package__.yml
+  inboxes: __package__.yml
+  inbox-events: ../inbox-events.yml
+
+service:
+  url: Http
+  base-path: /inboxes/{inbox_id}/events
+  path-parameters:
+    inbox_id: inboxes.InboxId
+  auth: true
+
+  endpoints:
+    list:
+      method: GET
+      path: ""
+      display-name: List Inbox Events
+      docs: |
+        List label change events for an inbox. Returns events in reverse chronological order by default. Use for IMAP UID projection or audit logging.
+
+        **CLI:**
+        ```bash
+        agentmail inboxes:events list --inbox-id <inbox_id>
+        ```
+      request:
+        name: ListInboxEventsRequest
+        query-parameters:
+          limit: optional<global.Limit>
+          page_token: optional<global.PageToken>
+          ascending: optional<global.Ascending>
+      response: inbox-events.ListInboxEventsResponse
+      errors:
+        - global.NotFoundError


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an Inbox Events API to list label add/remove events for an inbox with pagination and sort controls. Supports IMAP UID projection and audit logging.

- **New Features**
  - GET `/inboxes/{inbox_id}/events` (auth). Query: `limit`, `page_token`, `ascending` (default reverse chronological).
  - Models: `InboxEvent` (org, pod, inbox, message, label, event_at, created_at), `InboxEventType` (`label_added`, `label_removed`), `ListInboxEventsResponse` (count, limit, next_page_token, events[]).
  - Events are ordered by `event_id` descending; returns `NotFoundError` if inbox is missing.
  - CLI: `agentmail inboxes:events list --inbox-id <inbox_id>`.

<sup>Written for commit 9eaf48c5ca76e2672f120e1787a5149988c73623. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

