### PR TITLE
fix(docs): use host-only Fern instance URLs

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -19,7 +19,7 @@ jobs:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
         run: |
-          OUTPUT=$(fern generate --docs --preview --instance https://agentmail-production.docs.buildwithfern.com --log-level debug 2>&1) || true
+          OUTPUT=$(fern generate --docs --preview --instance agentmail-production.docs.buildwithfern.com --log-level debug 2>&1) || true
           echo "$OUTPUT"
           URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')
           echo "Preview URL: $URL"

--- a/bin/agentmail-docs.ts
+++ b/bin/agentmail-docs.ts
@@ -3,9 +3,10 @@ import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
 const fernDir = join(dirname(fileURLToPath(import.meta.url)), "..", "fern");
+
 const instances = [
-  "https://agentmail-production.docs.buildwithfern.com",
-  "https://agentmail-production.docs.buildwithfern.com/docs",
+  "agentmail-production.docs.buildwithfern.com",
+  "agentmail-production.docs.buildwithfern.com/docs",
 ] as const;
 
 function fern(args: string[]) {

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -3,14 +3,14 @@ css: ./styles.css
 js: ./custom.js
 
 instances:
-  - url: https://agentmail-production.docs.buildwithfern.com
+  - url: agentmail-production.docs.buildwithfern.com
     custom-domain: docs.agentmail.to
     edit-this-page:
       github:
         owner: agentmail-to
         repo: agentmail-docs
         branch: main
-  - url: https://agentmail-production.docs.buildwithfern.com/docs
+  - url: agentmail-production.docs.buildwithfern.com/docs
     custom-domain: agentmail.to/docs
     edit-this-page:
       github:


### PR DESCRIPTION
Fern prepends https:// in prompts and expects instance urls without a scheme in docs.yml. Align bin script, CI preview, and docs.yml.

Made-with: Cursor