### PR TITLE
update on event log label add remove

### DIFF
--- a/fern/definition/inbox-events.yml
+++ b/fern/definition/inbox-events.yml
@@ -12,10 +12,16 @@ types:
   InboxEventType:
     enum:
       - name: LABEL_ADDED
-        value: label_added
+        value: label.added
       - name: LABEL_REMOVED
-        value: label_removed
-    docs: Type of inbox event.
+        value: label.removed
+    docs: |
+      Type of inbox event. Wire format is dot.case to match the
+      convention used by webhook events (`message.received`,
+      `domain.verified`, etc. in events.yml). Pre-2026-04 these were
+      `label_added`/`label_removed` (snake_case). The Fern enum's `name`
+      field stays uppercase-snake (Fern convention); only the wire
+      `value` changed.
 
   InboxEvent:
     properties:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches inbox label event wire values to dot.case to match webhook conventions. Enum names stay the same; wire values change from `label_added`/`label_removed` to `label.added`/`label.removed`.

- **Migration**
  - Update any parsers, filters, and DB/analytics to expect `label.added` and `label.removed`.
  - Regenerate and redeploy SDKs/clients from the updated Fern definitions.
  - If you store historical values, keep compatibility for `label_added`/`label_removed` during rollout.

<sup>Written for commit 06a1edcbad7083f0e615f7c00d45899997f31842. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

