### PR TITLE
adding unauthenticated emails

### DIFF
--- a/fern/definition/__package__.yml
+++ b/fern/definition/__package__.yml
@@ -37,6 +37,10 @@ types:
     type: boolean
     docs: Include blocked in results.
 
+  IncludeUnauthenticated:
+    type: boolean
+    docs: Include unauthenticated in results.
+
   IncludeTrash:
     type: boolean
     docs: Include trash in results.

--- a/fern/definition/inboxes/messages.yml
+++ b/fern/definition/inboxes/messages.yml
@@ -34,6 +34,7 @@ service:
           ascending: optional<global.Ascending>
           include_spam: optional<global.IncludeSpam>
           include_blocked: optional<global.IncludeBlocked>
+          include_unauthenticated: optional<global.IncludeUnauthenticated>
           include_trash: optional<global.IncludeTrash>
       response: messages.ListMessagesResponse
       errors:

--- a/fern/definition/inboxes/threads.yml
+++ b/fern/definition/inboxes/threads.yml
@@ -34,6 +34,7 @@ service:
           ascending: optional<global.Ascending>
           include_spam: optional<global.IncludeSpam>
           include_blocked: optional<global.IncludeBlocked>
+          include_unauthenticated: optional<global.IncludeUnauthenticated>
           include_trash: optional<global.IncludeTrash>
       response: threads.ListThreadsResponse
       errors:

--- a/fern/definition/pods/threads.yml
+++ b/fern/definition/pods/threads.yml
@@ -34,6 +34,7 @@ service:
           ascending: optional<global.Ascending>
           include_spam: optional<global.IncludeSpam>
           include_blocked: optional<global.IncludeBlocked>
+          include_unauthenticated: optional<global.IncludeUnauthenticated>
           include_trash: optional<global.IncludeTrash>
       response: threads.ListThreadsResponse
       errors:

--- a/fern/definition/threads.yml
+++ b/fern/definition/threads.yml
@@ -157,6 +157,7 @@ service:
           ascending: optional<global.Ascending>
           include_spam: optional<global.IncludeSpam>
           include_blocked: optional<global.IncludeBlocked>
+          include_unauthenticated: optional<global.IncludeUnauthenticated>
           include_trash: optional<global.IncludeTrash>
       response: ListThreadsResponse
       errors:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add optional support for including unauthenticated emails in list endpoints. Adds `include_unauthenticated` so clients can fetch messages and threads from unauthenticated senders when needed.

- **New Features**
  - New global flag `IncludeUnauthenticated` (boolean).
  - Added `include_unauthenticated` to `inboxes/messages.list`, `inboxes/threads.list`, `pods/threads.list`, and `threads.list`.
  - Default behavior unchanged: unauthenticated items are excluded unless set.

<sup>Written for commit 862f5cb97092eca2d51c5970201843c327c1c6ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

