### PR TITLE
adding batch get message

### DIFF
--- a/fern/definition/inboxes/messages.yml
+++ b/fern/definition/inboxes/messages.yml
@@ -55,6 +55,24 @@ service:
       errors:
         - global.NotFoundError
 
+    batchGet:
+      method: POST
+      path: /batch-get
+      display-name: Batch Get Messages
+      docs: |
+        Fetch metadata for up to 500 messages in one request. Missing or
+        restricted IDs are silently omitted; compare `count` against `limit`
+        to detect misses.
+
+        **CLI:**
+        ```bash
+        agentmail inboxes:messages batch-get --inbox-id <inbox_id> --message-id <id1> --message-id <id2>
+        ```
+      request: messages.BatchGetMessagesRequest
+      response: messages.BatchGetMessagesResponse
+      errors:
+        - global.ValidationError
+
     getAttachment:
       method: GET
       path: /{message_id}/attachments/{attachment_id}

--- a/fern/definition/messages.yml
+++ b/fern/definition/messages.yml
@@ -145,6 +145,29 @@ types:
         type: list<MessageItem>
         docs: Ordered by `timestamp` descending.
 
+  BatchGetMessagesMessageIds:
+    type: list<MessageId>
+    docs: |
+      IDs of messages to fetch. Maximum 500 ids per request. Duplicates are
+      rejected with a validation error. IDs not found in the inbox (including
+      cross-inbox or permission-restricted) are silently omitted from the
+      response; callers detect misses by comparing `count` against `limit`.
+
+  BatchGetMessagesRequest:
+    properties:
+      message_ids: BatchGetMessagesMessageIds
+
+  BatchGetMessagesResponse:
+    properties:
+      limit: global.Limit
+      count: global.Count
+      messages:
+        type: list<Message>
+        docs: |
+          Found messages. Order matches `message_ids` in the request. Body
+          fields (`text`, `html`, `extracted_text`, `extracted_html`) are
+          never populated; use the single-message endpoint to retrieve bodies.
+
   RawMessageResponse:
     docs: S3 presigned URL to download the raw .eml file.
     properties:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a batch-get endpoint to fetch message metadata for up to 500 messages in one request. This reduces API round-trips and speeds up inbox tooling.

- New Features
  - Added POST batchGet for inbox messages to retrieve up to 500 message metadata in one call.
  - Request takes message_ids (max 500); duplicates return a ValidationError. Missing or restricted IDs are omitted; compare count vs limit to detect misses. Order matches the request.
  - Response returns metadata only; body fields are not included. Use the single-message endpoint to fetch bodies.
  - Added CLI docs for `agentmail inboxes:messages batch-get`.

<sup>Written for commit fd97971b8a8afcdc356f295093003b697b95f5eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

