### PR TITLE
[ENG-513] update-webhook filterTypes

### DIFF
--- a/fern/definition/webhooks/__package__.yml
+++ b/fern/definition/webhooks/__package__.yml
@@ -51,7 +51,12 @@ types:
   CreateWebhookRequest:
     properties:
       url: Url
-      event_types: events.EventTypes
+      event_types:
+        type: events.EventTypes
+        docs: |
+          Full list of event types this webhook should receive. At least one type is required. Send every type you
+          want in this array (not incremental). See [Webhooks overview](https://docs.agentmail.to/webhooks-overview)
+          for spam, blocked, and unauthenticated events and required permissions.
       pod_ids: optional<events.PodIds>
       inbox_ids: optional<events.InboxIds>
       client_id: optional<ClientId>
@@ -70,6 +75,15 @@ types:
       remove_pod_ids:
         type: optional<events.PodIds>
         docs: Pod IDs to unsubscribe from the webhook.
+      event_types:
+        type: optional<events.EventTypes>
+        docs: |
+          When you send a non-empty list, it replaces the webhook's subscribed event types in full (the same
+          "set the list" behavior as create). It is not a merge or diff: include every event type you want after
+          the update. Sending a one-element array means the webhook will only receive that one type afterward.
+          Omit this field or send an empty array to leave event types unchanged. Clearing all types with an empty
+          list is not supported. Subscribing to `message.received.spam`, `message.received.blocked`, or
+          `message.received.unauthenticated` requires the matching label permission on the API key.
 
 service:
   url: Http
@@ -128,6 +142,9 @@ service:
       path: /{webhook_id}
       display-name: Update Webhook
       docs: |
+        Update inbox or pod subscriptions, or replace the webhook's `event_types` in full when you pass a
+        non-empty `event_types` array (see request field docs). Inbox and pod changes use add/remove lists.
+
         **CLI:**
         ```bash
         agentmail webhooks update --webhook-id <webhook_id> --add-inbox-id <inbox_id>

--- a/fern/pages/webhooks/webhooks-overview.mdx
+++ b/fern/pages/webhooks/webhooks-overview.mdx
@@ -40,6 +40,15 @@ AgentMail supports ten webhook event types. When creating a webhook, you can sub
   Spam, blocked, and unauthenticated events are excluded by default. To receive them, explicitly include `message.received.spam`, `message.received.blocked`, or `message.received.unauthenticated` in the `event_types` list when creating a webhook. These messages are no longer sent as `message.received`.
 </Callout>
 
+## Updating `event_types` on a webhook
+
+When you [update a webhook](https://docs.agentmail.to/api-reference/webhooks/update-webhook), you can change which events it receives by sending `event_types` on `PATCH`:
+
+- **Non-empty array:** Replaces the webhook's subscribed event types **in full** (same idea as create: you set the whole list, not a diff). If you send only one type, the webhook will only receive that type afterward.
+- **Omitted or empty array:** Leaves the current event types unchanged. You cannot clear all subscriptions by sending an empty list.
+
+Subscribing to `message.received.spam`, `message.received.blocked`, or `message.received.unauthenticated` on update still requires the same [label permissions](/core-concepts/permissions) as on create.
+
 ## The Webhook Workflow
 
 The process is straightforward:
@@ -188,12 +197,13 @@ Copy one of the blocks below into Cursor or Claude for complete Webhooks API kno
   API reference:
   - webhooks.create(url, event_types?, inbox_ids?, pod_ids?, client_id?)
   - webhooks.get(webhook_id), webhooks.list(limit?, page_token?)
-  - webhooks.update(webhook_id, add_inbox_ids?, remove_inbox_ids?, add_pod_ids?, remove_pod_ids?)
+  - webhooks.update(webhook_id, add_inbox_ids?, remove_inbox_ids?, add_pod_ids?, remove_pod_ids?, event_types?)
   - webhooks.delete(webhook_id)
 
   Events: message.received, message.received.spam, message.received.blocked, message.received.unauthenticated, message.sent, message.delivered, message.bounced, message.complained, message.rejected, domain.verified
   Payload: event_type, event_id, plus message/send/delivery/bounce/complaint/reject/domain. Verify with Svix (webhook.secret).
   Note: message.received.spam, message.received.blocked, and message.received.unauthenticated are excluded by default. To receive them, explicitly include them in event_types and ensure the API key has label_spam_read / label_blocked_read permissions for spam and blocked events.
+  On update, non-empty event_types replaces the subscribed list in full (omit or [] to leave types unchanged).
   """
   import os
   from dotenv import load_dotenv
@@ -217,11 +227,12 @@ Copy one of the blocks below into Cursor or Claude for complete Webhooks API kno
    * API reference:
    * - webhooks.create({ url, eventTypes?, inboxIds?, podIds?, clientId? })
    * - webhooks.get(webhookId), webhooks.list({ limit?, pageToken? })
-   * - webhooks.update(webhookId, { addInboxIds?, removeInboxIds?, addPodIds?, removePodIds? })
+   * - webhooks.update(webhookId, { addInboxIds?, removeInboxIds?, addPodIds?, removePodIds?, eventTypes? })
    * - webhooks.delete(webhookId)
    *
    * Events: message.received, message.received.spam, message.received.blocked, message.received.unauthenticated, message.sent, message.delivered, message.bounced, message.complained, message.rejected, domain.verified
    * Note: message.received.spam, message.received.blocked, and message.received.unauthenticated are excluded by default. To receive them, explicitly include them in eventTypes and ensure the API key has label_spam_read / label_blocked_read permissions for spam and blocked events.
+   * On update, non-empty eventTypes replaces the subscribed list in full (omit or [] to leave types unchanged).
    * Verify with Svix using webhook.secret. Use express.raw() for body—signature needs raw payload.
    */
   import { AgentMailClient } from "agentmail";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable updating a webhook’s subscribed event types via `PATCH /webhooks/{webhook_id}` using `event_types`. Non-empty arrays replace the full list; omit or [] leaves it unchanged. Addresses ENG-513.

- **New Features**
  - Added `event_types?` to `webhooks.update` request. Non-empty replaces all types; omit or `[]` keeps current; clearing all is not supported. Permissions required for `message.received.spam`, `message.received.blocked`, and `message.received.unauthenticated`.
  - Improved docs: clarified create/update behavior, added an “Updating event_types” section, and updated API snippets to include `event_types` on update.

<sup>Written for commit a7216c34232365e678f930dc04c3e04a80c3710f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

