### PR TITLE
docs: fix SMTP username guidance

### DIFF
--- a/fern/pages/guides/imap-smtp.mdx
+++ b/fern/pages/guides/imap-smtp.mdx
@@ -146,7 +146,7 @@ Use SMTP to send emails from your AgentMail inbox.
 | ------------ | ------------------------------ |
 | **Host**     | `smtp.agentmail.to`            |
 | **Port**     | `465`                          |
-| **Username** | agentmail                      |
+| **Username** | Your inbox email (e.g., `myinbox@agentmail.to`) |
 | **Password** | Your API key                   |
 | **SSL/TLS**  | **Required** (must be enabled) |
 
@@ -225,6 +225,7 @@ sendEmail().catch(console.error);
 | Error                   | Cause                   | Solution                                               |
 | ----------------------- | ----------------------- | ------------------------------------------------------ |
 | "Authentication failed" | Invalid credentials     | Verify your inbox email and API key from the console   |
+| "Authentication failed" | Username set to `agentmail` | Use your inbox email address as the SMTP username      |
 | "Connection refused"    | SSL not enabled         | Enable SSL/TLS in your client settings                 |
 | "Connection timeout"    | Firewall blocking ports | Ensure ports 993 (IMAP) and 465/587 (SMTP) are open    |
 | "Sender not authorized" | Wrong From address      | Use your inbox's email address as the From address     |


### PR DESCRIPTION
## Summary
- align the SMTP configuration table with the working Python and TypeScript examples
- clarify that the SMTP username should be the inbox email address, not `agentmail`
- add a troubleshooting row for authentication failures caused by the old username value

Fixes #148.

## Verification
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies in SMTP docs that the username is your inbox email address (e.g., `myinbox@agentmail.to`), not `agentmail`. Aligns the configuration table with the Python/TypeScript examples and adds a troubleshooting tip for auth failures; fixes #148.

<sup>Written for commit 43678fb67bdd73d40b5a6ad3d201a152151380fe. Summary will update on new commits. <a href="https://cubic.dev/pr/agentmail-to/agentmail-docs/pull/156?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

