### PR TITLE
fixed indentation for core-concepts messages

### DIFF
--- a/fern/pages/core-concepts/messages.mdx
+++ b/fern/pages/core-concepts/messages.mdx
@@ -46,15 +46,15 @@ To start a new conversation, you can send a `Message` from one of your inboxes. 
 # Let's assume we have one:
 
 sent_message = client.inboxes.messages.send(
-inbox_id = 'my_inbox@domain.com',
-to = 'recipient@domain.com',
-labels=[
-"outreach",
-"startup"
-],
-subject="[YC S25] Founder Reachout ",
-text="Hello, I'm Michael, and I'm a founder at AgentMail...",
-html="<div dir=\"ltr\">Hello,<br><br>I'm Michael, and I'm a founder at AgentMail..."
+    inbox_id = 'my_inbox@domain.com',
+    to = 'recipient@domain.com',
+    labels=[
+        "outreach",
+        "startup"
+    ],
+    subject="[YC S25] Founder Reachout ",
+    text="Hello, I'm Michael, and I'm a founder at AgentMail...",
+    html="<div dir=\"ltr\">Hello,<br><br>I'm Michael, and I'm a founder at AgentMail..."
 )
 print(f"Message sent successfully with ID: {sent_message.message_id}")
 


### PR DESCRIPTION
<img width="677" height="419" alt="Screenshot 2026-05-20 at 3 20 25 PM" src="https://github.com/user-attachments/assets/e9e1fa3a-8cb8-4ceb-8a4a-105e41bfeabb" />


Simple change under "Send a New Message" in https://www.agentmail.to/docs/messages to preserve indentation, autoformatting might have caused the issue