### PR TITLE
adding read only boolean to list entry in org

### DIFF
--- a/fern/definition/lists.yml
+++ b/fern/definition/lists.yml
@@ -38,6 +38,9 @@ types:
       created_at:
         type: datetime
         docs: Time at which entry was created.
+      read_only:
+        type: optional<boolean>
+        docs: Whether the entry is read-only and cannot be deleted via the API.
 
   ListEntry:
     extends: ListEntryBase


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an optional `read_only` boolean to `ListEntry` (via `ListEntryBase`) to mark entries that cannot be deleted through the API. This is non-breaking; clients will see the new field after SDK regeneration.

<sup>Written for commit f0501403c6602070e79b067c11fd6d7e3bfbdc3b. Summary will update on new commits. <a href="https://cubic.dev/pr/agentmail-to/agentmail-docs/pull/160?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

