### PR TITLE
Document inbox metadata

### DIFF
--- a/fern/changelog/2026-05-28.mdx
+++ b/fern/changelog/2026-05-28.mdx
@@ -1,0 +1,68 @@
+---
+tags: ["inboxes-api", "new-feature"]
+---
+
+## Summary
+
+Inboxes now support custom `metadata`: your own key-value data attached to any inbox. Link an inbox to records in your own system, such as a tenant ID, user ID, or feature flags, and read it back on every inbox response. Build agents that carry your application's context wherever an inbox goes.
+
+### What's new?
+
+**New features:**
+- **Inbox metadata**: Attach custom key-value pairs to an inbox. Values may be a string, number, or boolean, with up to 256 keys per inbox.
+
+**Changes:**
+- The `Inbox` object now includes an optional `metadata` field, returned on get, list, and create responses.
+- `POST /v0/inboxes` accepts a `metadata` field to set metadata at creation time.
+- `PATCH /v0/inboxes/:inbox_id` accepts a `metadata` field. Updates merge into existing metadata: keys you include are added or overwritten, and keys you omit are preserved. Send a key with a null value to remove it, or set `metadata` to null to clear everything. Each update must include at least one of `display_name` or `metadata`.
+
+### Use cases
+
+Build agents that:
+- Tag each inbox with a tenant or customer ID so you can map inboxes back to your own data model
+- Store per-inbox feature flags or routing hints that your agent reads at runtime
+- Track lifecycle state, such as an onboarding step or campaign name, directly on the inbox
+- Filter and organize a large fleet of inboxes by the attributes that matter to your application
+
+<CodeBlocks>
+
+```python title="Python"
+from agentmail import AgentMail
+
+client = AgentMail(api_key="your-api-key")
+
+# attach metadata when creating an inbox
+inbox = client.inboxes.create(
+    username="support-agent",
+    metadata={"tenant_id": "acme", "tier": "pro", "active": True},
+)
+
+# merge in a change; omitted keys are preserved
+client.inboxes.update(
+    inbox_id=inbox.inbox_id,
+    metadata={"tier": "enterprise"},
+)
+```
+
+```typescript title="TypeScript"
+import { AgentMailClient } from "agentmail";
+
+const client = new AgentMailClient({ apiKey: "your-api-key" });
+
+// attach metadata when creating an inbox
+const inbox = await client.inboxes.create({
+  username: "support-agent",
+  metadata: { tenant_id: "acme", tier: "pro", active: true },
+});
+
+// merge in a change; omitted keys are preserved
+await client.inboxes.update(inbox.inboxId, {
+  metadata: { tier: "enterprise" },
+});
+```
+
+</CodeBlocks>
+
+<Note>
+  Learn more about attaching and updating inbox data in the [Inboxes metadata guide](https://docs.agentmail.to/inboxes#metadata).
+</Note>

--- a/fern/definition/inboxes/__package__.yml
+++ b/fern/definition/inboxes/__package__.yml
@@ -43,9 +43,6 @@ types:
     docs: |
       Custom key-value pairs attached to the inbox. Up to 256 keys. Keys and
       string values are each limited to 256 characters.
-    examples:
-      - value:
-          metadata_key: metadata_value
 
   Inbox:
     properties:

--- a/fern/definition/inboxes/__package__.yml
+++ b/fern/definition/inboxes/__package__.yml
@@ -30,6 +30,23 @@ types:
     type: string
     docs: Client ID of inbox.
 
+  MetadataValue:
+    discriminated: false
+    union:
+      - string
+      - double
+      - boolean
+    docs: A metadata value. May be a string, number, or boolean.
+
+  Metadata:
+    type: map<string, MetadataValue>
+    docs: |
+      Custom key-value pairs attached to the inbox. Up to 256 keys. Keys and
+      string values are each limited to 256 characters.
+    examples:
+      - value:
+          metadata_key: metadata_value
+
   Inbox:
     properties:
       pod_id: pods.PodId
@@ -37,6 +54,9 @@ types:
       email: Email
       display_name: optional<DisplayName>
       client_id: optional<ClientId>
+      metadata:
+        type: optional<Metadata>
+        docs: Custom metadata attached to the inbox.
       updated_at:
         type: datetime
         docs: Time at which inbox was last updated.
@@ -63,10 +83,20 @@ types:
         docs: Domain of address. Must be verified domain. Defaults to `agentmail.to`.
       display_name: optional<DisplayName>
       client_id: optional<ClientId>
+      metadata:
+        type: optional<Metadata>
+        docs: Custom metadata to attach to the inbox.
 
   UpdateInboxRequest:
     properties:
-      display_name: DisplayName
+      display_name: optional<DisplayName>
+      metadata:
+        type: optional<Metadata>
+        docs: |
+          Metadata to merge into the inbox's existing metadata. Keys you include
+          are added or overwritten; keys you omit are left unchanged. To remove a
+          single key, send it with a null value. To clear all metadata, send
+          `metadata` as null. Provide at least one of `display_name` or `metadata`.
 
 service:
   url: Http
@@ -135,6 +165,7 @@ service:
       response: Inbox
       errors:
         - global.NotFoundError
+        - global.ValidationError
 
     delete:
       method: DELETE

--- a/fern/pages/core-concepts/inboxes.mdx
+++ b/fern/pages/core-concepts/inboxes.mdx
@@ -140,6 +140,99 @@ agentmail inboxes list
   domains](/guides/domains/managing-domains) to learn more.
 </Tip>
 
+## Metadata
+
+Attach your own key-value data to any `Inbox` with the `metadata` field. Use it to link an inbox to records in your own system: a user ID, an agent name, or feature flags. Metadata is returned on every inbox response.
+
+Values may be a string, number, or boolean. An `Inbox` can hold up to 256 keys, and each key and string value is limited to 256 characters.
+
+<CodeBlocks>
+
+```python title="Python"
+# Attach metadata when creating an inbox; values may be a string, int, float, or boolean
+inbox = client.inboxes.create(
+    username="support-agent",
+    metadata={
+        "tenant_id": "acme",       # string
+        "seat_count": 5,           # int
+        "monthly_spend": 19.99,    # float
+        "active": True,            # boolean
+    },
+)
+
+# Read it back from any inbox response
+print(inbox.metadata)
+```
+
+```typescript title="TypeScript"
+// Attach metadata when creating an inbox; values may be a string, int, float, or boolean
+const inbox = await client.inboxes.create({
+  username: "support-agent",
+  metadata: {
+    tenant_id: "acme", // string
+    seat_count: 5, // int
+    monthly_spend: 19.99, // float
+    active: true, // boolean
+  },
+});
+
+// Read it back from any inbox response
+console.log(inbox.metadata);
+```
+
+</CodeBlocks>
+
+### Updating metadata
+
+Updates **merge** into the inbox's existing metadata — keys you include are added or overwritten, and keys you omit are preserved.
+
+<Note>
+  To remove a single key, send it with a `null` value. To clear all metadata at
+  once, send `metadata` as `null`. Every update must include either
+  `display_name` or `metadata`.
+</Note>
+
+<CodeBlocks>
+
+```python title="Python"
+# Add or overwrite keys; the keys you omit stay unchanged
+client.inboxes.update(
+    inbox_id="support-agent@agentmail.to",
+    metadata={"tier": "enterprise"},
+)
+
+# Remove a single key
+client.inboxes.update(
+    inbox_id="support-agent@agentmail.to",
+    metadata={"tier": None},
+)
+
+# Clear all metadata
+client.inboxes.update(
+    inbox_id="support-agent@agentmail.to",
+    metadata=None,
+)
+```
+
+```typescript title="TypeScript"
+// Add or overwrite keys; the keys you omit stay unchanged
+await client.inboxes.update("support-agent@agentmail.to", {
+  metadata: { tier: "enterprise" },
+});
+
+// Remove a single key
+await client.inboxes.update("support-agent@agentmail.to", {
+  metadata: { tier: null },
+});
+
+// Clear all metadata
+await client.inboxes.update("support-agent@agentmail.to", {
+  metadata: null,
+});
+```
+
+</CodeBlocks>
+
 ## Inbox-scoped API keys
 
 You can create API keys that are restricted to a single inbox. An inbox-scoped key can only access that inbox's threads, messages, and drafts. This is useful when you want to give an agent or integration the minimum access it needs.
@@ -180,10 +273,10 @@ Copy one of the blocks below into Cursor or Claude for complete Inboxes API know
   Setup: pip install agentmail python-dotenv. Set AGENTMAIL_API_KEY in .env.
 
   API reference:
-  - inboxes.create(username?, domain?, display_name?, client_id?) — client_id for idempotent retries
+  - inboxes.create(username?, domain?, display_name?, client_id?, metadata?) — client_id for idempotent retries; metadata is custom key-value data
   - inboxes.get(inbox_id)
   - inboxes.list(limit?, page_token?)
-  - inboxes.update(inbox_id, display_name)
+  - inboxes.update(inbox_id, display_name?, metadata?) — at least one field required; metadata is merged, not replaced
   - inboxes.delete(inbox_id)
   - inboxes.api_keys.create(inbox_id, name) — inbox-scoped key
   - inboxes.api_keys.list(inbox_id)
@@ -214,10 +307,10 @@ Copy one of the blocks below into Cursor or Claude for complete Inboxes API know
    * Setup: npm install agentmail dotenv. Set AGENTMAIL_API_KEY in .env.
    *
    * API reference:
-   * - inboxes.create({ username?, domain?, displayName?, clientId? })
+   * - inboxes.create({ username?, domain?, displayName?, clientId?, metadata? }) — metadata is custom key-value data
    * - inboxes.get(inboxId)
    * - inboxes.list({ limit?, pageToken? })
-   * - inboxes.update(inboxId, { displayName })
+   * - inboxes.update(inboxId, { displayName?, metadata? }) — at least one field required
    * - inboxes.delete(inboxId)
    * - inboxes.apiKeys.create(inboxId, { name }) — inbox-scoped key
    * - inboxes.apiKeys.list(inboxId)


### PR DESCRIPTION
## Summary

Documents the new inbox `metadata` field — custom key-value data attachable to any inbox (string/number/boolean values, up to 256 keys, keys and string values ≤256 chars).

## Changes

- **API definition** (`fern/definition/inboxes/__package__.yml`)
  - New `MetadataValue` (string | double | boolean) and `Metadata` (`map<string, MetadataValue>`) types
  - `metadata` field added to `Inbox`, `CreateInboxRequest`, and `UpdateInboxRequest`
  - `UpdateInboxRequest.display_name` relaxed to optional; `ValidationError` added to the update endpoint
- **Concepts page** (`fern/pages/core-concepts/inboxes.mdx`)
  - New **Metadata** section (purpose, value types, limits, create example)
  - New **Updating metadata** subsection documenting merge-on-update and null delete / null clear semantics
  - Copy-for-Cursor reference updated (kept terse — the merge-not-replace warning, full mechanics live in the section above)
- **Changelog** (`fern/changelog/2026-05-28.mdx`) — feature entry

## Verification

All copy was cross-checked against the backend contract in `agentmail-api` (`src/schemas/inbox.ts`, `src/utils/inbox-metadata.ts`): value types, the 256 limits, and the null-delete / null-clear / merge semantics all match `applyMetadataDiff`. Rendered locally via `fern docs dev`; YAML/MDX validate and reload cleanly.

> **Note:** The `agentmail-cli` does not yet expose a `--metadata` flag (and still requires `--display-name` on update), so CLI examples were intentionally omitted from the metadata sections. The CLI needs regenerating against the current spec to catch up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)