### PR TITLE
Use nullable (not optional) for Update Inbox metadata values

### DIFF
--- a/fern/definition/inboxes/__package__.yml
+++ b/fern/definition/inboxes/__package__.yml
@@ -46,7 +46,7 @@ types:
       send a key with a null value to remove that key.
 
   UpdateMetadata:
-    type: map<string, optional<MetadataValue>>
+    type: map<string, nullable<MetadataValue>>
     docs: |
       Custom key-value pairs to merge into the inbox's existing metadata. A
       value may be a string, number, boolean, or null. Setting a key to null
@@ -97,12 +97,14 @@ types:
     properties:
       display_name: optional<DisplayName>
       metadata:
-        type: optional<UpdateMetadata>
+        type: optional<nullable<UpdateMetadata>>
         docs: |
           Metadata to merge into the inbox's existing metadata. Keys you include
           are added or overwritten; keys you omit are left unchanged. To remove a
           single key, send it with a null value. To clear all metadata, send
-          `metadata` as null.
+          `metadata` as null. Sending an empty object is rejected; use null to
+          clear. Each update must include at least one of `display_name` or
+          `metadata`.
 
 service:
   url: Http


### PR DESCRIPTION
## Summary
Follow-up to #167. Switches the Update Inbox `metadata` field and per-key value from `optional<>` to `nullable<>` so that `null` (the remove/clear signal) survives instead of being scrubbed as an omitted value.

- `UpdateMetadata`: `map<string, optional<MetadataValue>>` → `map<string, nullable<MetadataValue>>` — `null` on a key removes that key
- `Update.metadata`: `optional<UpdateMetadata>` → `optional<nullable<UpdateMetadata>>` — `metadata: null` clears all metadata
- Documents that an empty object is rejected (use `null` to clear) and that each update must include at least one of `display_name` or `metadata`

Matches the agentmail-api schema (`MetadataValueSchema.nullable()` and `UpdateMetadataSchema.nullable().optional()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)