### PR TITLE
Document subdomains (subdomains_enabled + wildcard MX)

### DIFF
--- a/fern/changelog/2026-06-08.mdx
+++ b/fern/changelog/2026-06-08.mdx
@@ -1,0 +1,60 @@
+---
+tags: ["domains-api", "inboxes-api", "new-feature"]
+---
+
+## Summary
+
+You can now create inboxes on any subdomain of a verified domain without registering each subdomain separately. Enable `subdomains_enabled` on a domain, publish the single wildcard MX record it returns, and create inboxes on any subdomain on demand. Build agents that spin up addresses like `agent@bot.example.com` or `support@team1.example.com` the moment you need them.
+
+### What's new?
+
+**New features:**
+- **Subdomains**: Opt in per domain with `subdomains_enabled`. When enabled, the domain's verification records include a wildcard MX record (`*.<domain>`) to publish on the top-level domain. Once it is published and verified, inboxes can be created on any subdomain of that domain.
+
+**Changes:**
+- `POST /v0/domains` accepts an optional `subdomains_enabled` flag (defaults to `false`).
+- `PATCH /v0/domains/:domain_id` now accepts `subdomains_enabled` and applies partial updates: send at least one of `feedback_enabled` or `subdomains_enabled`, and omitted fields are left unchanged. Enabling subdomains on an already-verified domain returns it to `pending` until the new wildcard MX record is published; sending is not interrupted.
+- Domain responses now include the `subdomains_enabled` field.
+- Creating an inbox on a subdomain of a domain that does not have subdomains enabled returns a `422` error.
+
+### Use cases
+
+Build agents that:
+- Provision a dedicated inbox per customer or workspace under one verified domain (`support@acme.example.com`)
+- Separate agent traffic onto purpose-named subdomains (`billing.`, `outreach.`, `support.`) without registering each one
+- Stand up short-lived inboxes on fresh subdomains for one-off tasks, then tear them down
+- Keep all agent addresses under a single domain you verify and manage once
+
+<CodeBlocks>
+
+```python title="Python"
+from agentmail import AgentMail
+
+client = AgentMail(api_key="your-api-key")
+
+# Enable subdomains on a verified domain
+domain = client.domains.update("example.com", subdomains_enabled=True)
+
+# Publish the new wildcard MX record, then create inboxes on any subdomain
+inbox = client.inboxes.create(username="agent", domain="bot.example.com")
+print(inbox.inbox_id)  # agent@bot.example.com
+```
+
+```typescript title="TypeScript"
+import { AgentMailClient } from "agentmail";
+
+const client = new AgentMailClient({ apiKey: "your-api-key" });
+
+// Enable subdomains on a verified domain
+const domain = await client.domains.update("example.com", { subdomainsEnabled: true });
+
+// Publish the new wildcard MX record, then create inboxes on any subdomain
+const inbox = await client.inboxes.create({ username: "agent", domain: "bot.example.com" });
+console.log(inbox.inboxId); // agent@bot.example.com
+```
+
+</CodeBlocks>
+
+<Note>
+  Learn more in the [Setting Up Subdomains](https://docs.agentmail.to/custom-domains#setting-up-subdomains) guide.
+</Note>

--- a/fern/definition/domains.yml
+++ b/fern/definition/domains.yml
@@ -60,6 +60,12 @@ types:
     type: boolean
     docs: Bounce and complaint notifications are sent to your inboxes.
 
+  SubdomainsEnabled:
+    type: boolean
+    docs: |
+      Allow inboxes on any subdomain of this domain. Adds a required wildcard MX
+      record (`*.<domain>`) to `records`.
+
   ClientId:
     type: string
     docs: Client ID of domain.
@@ -71,9 +77,12 @@ types:
       domain: DomainName
       status: Status
       feedback_enabled: FeedbackEnabled
+      subdomains_enabled: SubdomainsEnabled
       records:
         type: list<VerificationRecord>
-        docs: A list of DNS records required to verify the domain.
+        docs: |
+          A list of DNS records required to verify the domain. Includes a
+          wildcard MX record (`*.<domain>`) when `subdomains_enabled` is true.
       client_id: optional<ClientId>
       updated_at:
         type: datetime
@@ -88,6 +97,7 @@ types:
       domain_id: DomainId
       domain: DomainName
       feedback_enabled: FeedbackEnabled
+      subdomains_enabled: SubdomainsEnabled
       client_id: optional<ClientId>
       updated_at:
         type: datetime
@@ -108,11 +118,18 @@ types:
   CreateDomainRequest:
     properties:
       domain: DomainName
-      feedback_enabled: FeedbackEnabled
+      feedback_enabled: optional<FeedbackEnabled>
+      subdomains_enabled: optional<SubdomainsEnabled>
 
   UpdateDomainRequest:
+    docs: |
+      Provide at least one of `feedback_enabled` or `subdomains_enabled`. Omitted
+      fields are left unchanged; an empty body is rejected. Enabling
+      `subdomains_enabled` on a verified domain returns it to `PENDING` until the
+      newly-required wildcard MX record (`*.<domain>`) is published and verified.
     properties:
       feedback_enabled: optional<FeedbackEnabled>
+      subdomains_enabled: optional<SubdomainsEnabled>
 
 service:
   url: Http

--- a/fern/definition/inboxes/__package__.yml
+++ b/fern/definition/inboxes/__package__.yml
@@ -86,7 +86,10 @@ types:
         docs: Username of address. Randomly generated if not specified.
       domain:
         type: optional<string>
-        docs: Domain of address. Must be verified domain. Defaults to `agentmail.to`.
+        docs: |
+          Domain of address. Must be a verified domain, or any subdomain of a
+          verified domain that has subdomains enabled (e.g., `bot.example.com`).
+          Defaults to `agentmail.to`.
       display_name: optional<DisplayName>
       client_id: optional<ClientId>
       metadata:
@@ -157,6 +160,7 @@ service:
       response: Inbox
       errors:
         - global.ValidationError
+        - global.UnprocessableError
 
     update:
       method: PATCH

--- a/fern/definition/pods/inboxes.yml
+++ b/fern/definition/pods/inboxes.yml
@@ -60,6 +60,7 @@ service:
       response: inboxes.Inbox
       errors:
         - global.ValidationError
+        - global.UnprocessableError
 
     update:
       method: PATCH

--- a/fern/pages/core-concepts/inboxes.mdx
+++ b/fern/pages/core-concepts/inboxes.mdx
@@ -136,8 +136,10 @@ agentmail inboxes list
 <Tip>
   When creating an `Inbox`, the `username` and `domain` are optional. If you
   don't provide them, AgentMail will generate a unique address for you using our
-  default domain. Check out our [guide on managing
-  domains](/guides/domains/managing-domains) to learn more.
+  default domain. You can also set `domain` to one of your verified custom
+  domains, or to any subdomain of a domain with [subdomains
+  enabled](/custom-domains#setting-up-subdomains). Check out our [guide on managing
+  domains](/managing-domains).
 </Tip>
 
 ## Metadata

--- a/fern/pages/guides/domains/custom-domains.mdx
+++ b/fern/pages/guides/domains/custom-domains.mdx
@@ -387,6 +387,105 @@ Here are instructions for some common DNS providers. This list is not exhaustive
   custom domain and building your agents!
 </Callout>
 
+## Setting Up Subdomains
+
+By default, a verified domain only hosts inboxes on the exact domain you registered (e.g. `agent@example.com`). To create inboxes on **arbitrary subdomains** (e.g. `agent@bot.example.com`, `support@sales.example.com`) without registering each subdomain as its own domain, enable **subdomains** on the parent domain.
+
+To set this up, add one new **required** record to your top-level domain: a wildcard MX (`*.example.com`). Once it's published and verified, you can create inboxes on any subdomain of the domain.
+
+<Steps>
+<Step title="1. Enable subdomains on the domain">
+
+Set `subdomains_enabled` when you create the domain, or turn it on later with an update.
+
+<CodeBlocks>
+```python title="Python"
+from agentmail import AgentMail
+
+client = AgentMail(api_key="YOUR_API_KEY")
+
+# Enable at creation
+domain = client.domains.create(domain="example.com", subdomains_enabled=True)
+
+# Or enable on an existing domain
+domain = client.domains.update("example.com", subdomains_enabled=True)
+
+print("DNS records:", domain.records)
+```
+
+```typescript title="TypeScript"
+import { AgentMailClient } from "agentmail";
+
+const client = new AgentMailClient({ apiKey: "YOUR_API_KEY" });
+
+// Enable at creation
+let domain = await client.domains.create({ domain: "example.com", subdomainsEnabled: true });
+
+// Or enable on an existing domain
+domain = await client.domains.update("example.com", { subdomainsEnabled: true });
+
+console.log("DNS records:", domain.records);
+```
+
+```bash title="cURL"
+# Enable on an existing domain
+curl -X PATCH https://api.agentmail.to/v0/domains/example.com \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"subdomains_enabled": true}'
+```
+</CodeBlocks>
+
+<Callout type="warning" title="Verified domains return to Pending">
+  Enabling subdomains on an already-verified domain adds the wildcard MX as a new required record, so the domain returns to `Pending` until that record is published and verified. Sending is not interrupted while this happens.
+</Callout>
+
+</Step>
+<Step title="2. Publish the wildcard MX record">
+
+The response `records` array (and the BIND zone file) now includes a wildcard MX. Add it to your DNS provider exactly like the other MX record, using `*` as the host:
+
+| Field       | Value                              |
+| :---------- | :--------------------------------- |
+| Type        | `MX`                               |
+| Name / Host | `*` (resolves to `*.example.com`)  |
+| Value       | `inbound-smtp.us-east-1.amazonaws.com` |
+| Priority    | `10`                               |
+
+<Callout type="info" title="If your domain is itself a subdomain">
+  If the domain you registered is itself a subdomain (e.g. `mail.example.com`), the wildcard is `*.mail.example.com`, so enter `*.mail` as the host. The console and zone file always show the exact name to use.
+</Callout>
+
+</Step>
+<Step title="3. Create inboxes on any subdomain">
+
+Once the domain is `Verified`, create an inbox on any subdomain by passing it as the `domain`:
+
+<CodeBlocks>
+```python title="Python"
+inbox = client.inboxes.create(username="agent", domain="bot.example.com")
+print(inbox.inbox_id)  # agent@bot.example.com
+```
+
+```typescript title="TypeScript"
+const inbox = await client.inboxes.create({ username: "agent", domain: "bot.example.com" });
+console.log(inbox.inboxId); // agent@bot.example.com
+```
+</CodeBlocks>
+
+You don't need to register `bot.example.com` separately: AgentMail routes it through the parent domain's wildcard MX. Creating a subdomain inbox on a domain that does **not** have subdomains enabled returns a `422` error.
+
+<Note>
+  Subdomain inboxes don't appear under `GET /domains` (only registered domains do); list your inboxes to see them.
+</Note>
+
+</Step>
+</Steps>
+
+<Note>
+  Inboxes on a subdomain send under the parent domain's identity and DKIM, so they share its sending reputation rather than building their own. To give a subdomain an isolated reputation, register it as a separate domain instead, see [Isolate reputations with subdomains](/managing-domains#strategy-1-isolate-reputations-with-subdomains).
+</Note>
+
 ## Troubleshooting Common DNS Issues
 
 DNS can be tricky. Here are some common issues and how to resolve them.

--- a/fern/pages/guides/domains/managing-domains.mdx
+++ b/fern/pages/guides/domains/managing-domains.mdx
@@ -36,6 +36,20 @@ Your domains are resources that can be fully managed through the API. Here are t
 
   </Accordion>
 
+  <Accordion title="Update a Domain">
+    Use the `PATCH /domains/{domain}` endpoint to change a domain's settings. Provide at least one of `feedback_enabled` or `subdomains_enabled`; omitted fields are left unchanged.
+
+    <EndpointRequestSnippet
+      endpoint="PATCH /domains/{domain}"
+      title="Update a Domain"
+    />
+
+    <Callout type="info">
+      Enabling `subdomains_enabled` adds a required wildcard MX record and returns a verified domain to `Pending` until that record is published and verified. See [Setting Up Subdomains](/custom-domains#setting-up-subdomains).
+    </Callout>
+
+  </Accordion>
+
   <Accordion title="Delete a Domain">
     If you no longer need a domain, you can remove it using the `DELETE /domains/{domain}` endpoint.
 
@@ -64,6 +78,8 @@ Different agents have different sending patterns and risk profiles. A transactio
 - **`billing.your-company.com`**: For critical transactional agents (receipts, invoices).
 - **`outreach.your-company.com`**: For high-volume sales or marketing agents.
 - **`support.your-company.com`**: For customer service and support agents.
+
+Registering each subdomain as its own domain gives it an independent sending identity (its own DKIM), which is what isolates its reputation. If you don't need isolated reputations and only want inboxes to live on many subdomains under one verified parent, [enable subdomains](/custom-domains#setting-up-subdomains) instead: turn them on once for the parent domain, publish the wildcard MX record, then create inboxes on any subdomain without registering each one. Inboxes created this way send under the parent domain's identity, so they share its sending reputation rather than building their own.
 
 ### Strategy 2: Scale Deliverability with Domain Pooling
 

--- a/fern/pages/knowledge-base/custom-domain-setup.mdx
+++ b/fern/pages/knowledge-base/custom-domain-setup.mdx
@@ -87,6 +87,8 @@ console.log(`Created: ${inbox.inboxId}`);
 // support@yourcompany.com
 ```
 
+To create inboxes on **any subdomain** of your domain (e.g. `support@bot.yourcompany.com`) without registering each subdomain separately, [enable subdomains](/custom-domains#setting-up-subdomains) on the domain and publish the wildcard MX record it returns.
+
 ## Tips
 
 - **Use a subdomain** (e.g., `mail.yourcompany.com`) if you don't want to modify your root domain's MX records or risk conflicts with existing email services

--- a/fern/pages/knowledge-base/mx-record-conflicts.mdx
+++ b/fern/pages/knowledge-base/mx-record-conflicts.mdx
@@ -40,6 +40,10 @@ const inbox = await client.inboxes.create({
 
 Then add the MX, SPF, and DKIM records for `agents.yourcompany.com` at your DNS provider. These records are completely separate from your root domain's records and will not affect your existing email.
 
+## Hosting inboxes on many subdomains
+
+The setup above puts all your agents on one subdomain. If you instead want inboxes spread across **many** subdomains (for example, one per team or customer), [enable subdomains](/custom-domains#setting-up-subdomains) on the domain you registered. With them enabled on `agents.yourcompany.com`, publishing a single wildcard MX record (`*.agents.yourcompany.com`) lets you create inboxes on any nested subdomain, such as `support@team1.agents.yourcompany.com`, without registering each one. Your root domain's email is never touched.
+
 ## Can I use my root domain?
 
 Yes, but only in these scenarios:


### PR DESCRIPTION
Documents the subdomain-receiving feature (ENG-555), against the flag-based model merged to backend `main` (PR #362). The definition edits drive both the API reference and the auto-generated Python/Node SDKs.

## API definition (SDK + API reference)
- `domains.yml`: new `subdomains_enabled` on `Domain`, `DomainItem`, and the Create/Update requests; `feedback_enabled` changed to optional (matches backend default); `records` doc notes the wildcard MX
- `inboxes/__package__.yml` + `pods/inboxes.yml`: create-inbox `domain` doc covers subdomains; added `422` (UnprocessableError) to create

## Guides / concept / KB
- `custom-domains.mdx`: new **Setting Up Subdomains** section (enable → publish wildcard MX → create on subdomain) + reputation/apex `<Note>`
- `managing-domains.mdx`: **Update a Domain** operation + reputation-linkage note in Strategy 1
- `core-concepts/inboxes.mdx`: subdomain mention in the create `<Tip>`
- KB `mx-record-conflicts.mdx` + `custom-domain-setup.mdx`: subdomain pointers

## Changelog
- `2026-06-08.mdx`: "Subdomains" entry

## Notes
- **Console UI steps deferred** — the Console subdomains UX is on an unmerged web branch; this PR should land in sync with that deploy.
- The SDK changelog version links can be filled in after the regen/release.
- Validated with `fern check` (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)