### PR TITLE
adding batch update message

### DIFF
--- a/fern/definition/inboxes/messages.yml
+++ b/fern/definition/inboxes/messages.yml
@@ -110,6 +110,27 @@ service:
       errors:
         - global.ValidationError
 
+    batchUpdate:
+      method: POST
+      path: /batch-update
+      display-name: Batch Update Messages
+      docs: |
+        Apply one label change to up to 50 messages in a single request. The
+        same add_labels and remove_labels apply to every message id, and at
+        least one of them must be provided. The update is atomic: either all
+        resolved messages are updated or none are. Missing or restricted ids
+        are silently excluded; compare `count` against `limit` to detect
+        exclusions.
+
+        **CLI:**
+        ```bash
+        agentmail inboxes:messages batch-update --inbox-id <inbox_id> --message-id <id1> --message-id <id2> --add-label read --remove-label unread
+        ```
+      request: messages.BatchUpdateMessagesRequest
+      response: messages.BatchUpdateMessagesResponse
+      errors:
+        - global.ValidationError
+
     getAttachment:
       method: GET
       path: /{message_id}/attachments/{attachment_id}

--- a/fern/definition/messages.yml
+++ b/fern/definition/messages.yml
@@ -203,6 +203,35 @@ types:
           fields (`text`, `html`, `extracted_text`, `extracted_html`) are
           never populated; use the single-message endpoint to retrieve bodies.
 
+  BatchUpdateMessagesMessageIds:
+    type: list<MessageId>
+    docs: |
+      IDs of messages to update. Maximum 50 ids per request. Duplicates are
+      rejected with a validation error. IDs not found in the inbox (including
+      cross-inbox or permission-restricted) are silently excluded from the
+      update; callers detect exclusions by comparing `count` against `limit`.
+
+  BatchUpdateMessagesRequest:
+    properties:
+      message_ids: BatchUpdateMessagesMessageIds
+      add_labels:
+        type: optional<UpdateMessageLabels>
+        docs: Label or labels to add to every message.
+      remove_labels:
+        type: optional<UpdateMessageLabels>
+        docs: Label or labels to remove from every message.
+
+  BatchUpdateMessagesResponse:
+    properties:
+      limit: global.Limit
+      count: global.Count
+      updates:
+        type: list<UpdateMessageResponse>
+        docs: |
+          Updated messages with their new labels. Order matches `message_ids`
+          in the request. Excluded ids are omitted, so `count` may be less than
+          `limit`.
+
   RawMessageResponse:
     docs: S3 presigned URL to download the raw .eml file.
     properties:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a batch update API to apply the same label changes to up to 50 inbox messages in one request. This reduces multiple calls and ensures atomic updates.

- **New Features**
  - POST `/batch-update` under inbox messages to add/remove labels across `message_ids` in one atomic operation; requires at least one of `add_labels` or `remove_labels`.
  - New types: `BatchUpdateMessagesRequest` and `BatchUpdateMessagesResponse` with max 50 IDs, no duplicates, and preserved order; excluded IDs are omitted and surfaced via `count` vs `limit`.
  - Docs include a CLI example for `agentmail inboxes:messages batch-update`.

<sup>Written for commit 5404048ac2a33fc868f7ae0c04102848f5dafe41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agentmail-to/agentmail-docs/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

