### PR TITLE
Document /metrics/events + /metrics/usage; drop bare /metrics

### DIFF
--- a/fern/changelog/2026-06-12.mdx
+++ b/fern/changelog/2026-06-12.mdx
@@ -1,0 +1,92 @@
+---
+tags: ["metrics-api", "new-feature"]
+---
+
+## Summary
+
+You can now track cumulative usage over time. The new usage endpoint returns running totals of storage, messages, threads, inboxes, domains, and pods — for your whole organization, a single pod, or a single inbox. Event counts also move to a dedicated `/metrics/events` path, so the metrics API now cleanly separates "what happened" (events) from "what you have" (usage).
+
+### What's new?
+
+**New endpoints:**
+- `GET /v0/metrics/usage` - Cumulative usage series for the organization.
+- `GET /v0/pods/:pod_id/metrics/usage` - Cumulative usage series for a pod.
+- `GET /v0/inboxes/:inbox_id/metrics/usage` - Cumulative usage series for an inbox.
+- `GET /v0/metrics/events` (and pod/inbox variants) - The canonical path for event counts, replacing bare `GET /v0/metrics`.
+
+**New features:**
+- **Usage series**: Each point is the running total of a usage type at that timestamp, not the change within the bucket. An idle scope renders a flat line at its current level, so charts stay meaningful even with no activity in the window.
+- **Usage types**: `storage_bytes`, `message_count`, `thread_count`, `inbox_count`, `domain_count`, and `pod_count`. Filter with the `usage_types` query parameter, or omit it to get every type the scope carries. Inboxes carry the first three; pods add `inbox_count` and `domain_count`; organizations add `pod_count`.
+- **Bucketing**: `period` sets the bucket size in seconds. The range divided by `period` must not exceed 1000 buckets — narrow the range or coarsen the period for fine-grained series.
+
+**Changes:**
+- `GET /v0/metrics` (and its pod/inbox variants) is replaced by `/metrics/events`. The old path still responds, so existing clients keep working, but it's removed from the docs and SDKs — use `client.metrics.events()` in place of `client.metrics.query()`.
+- Metric queries now clamp a future `end` to the current time instead of returning phantom future points, and `period`/`limit` must be whole numbers.
+- The documented metric event types now match what the API accepts: added `message.received.spam`, `message.received.blocked`, `message.received.unauthenticated`, and `domain.verified`; removed `message.delayed`, which the API never accepted.
+
+### Use cases
+
+Build agents that:
+- Chart storage growth over time and archive old threads before hitting quota
+- Monitor message and thread volume per inbox to spot runaway automations
+- Verify cleanup actually happened by watching usage drop after bulk deletes
+- Compare pods by inbox and domain footprint to balance workloads
+
+<CodeBlocks>
+
+```python title="Python"
+from agentmail import AgentMail
+
+client = AgentMail(api_key="your-api-key")
+
+# storage growth for the last week, one point per hour
+usage = client.metrics.usage(
+    usage_types=["storage_bytes"],
+    start="2026-06-05T00:00:00Z",
+    period=3600,
+)
+
+for point in usage["storage_bytes"]:
+    print(point.timestamp, point.value)
+
+# usage for a single inbox (storage, messages, threads)
+inbox_usage = client.inboxes.metrics.usage(inbox_id="support@agentmail.to")
+
+# event counts now live at /metrics/events
+events = client.metrics.events(
+    event_types=["message.sent", "message.bounced"],
+    period=3600,
+)
+```
+
+```typescript title="TypeScript"
+import { AgentMailClient } from "agentmail";
+
+const client = new AgentMailClient({ apiKey: "your-api-key" });
+
+// storage growth for the last week, one point per hour
+const usage = await client.metrics.usage({
+  usageTypes: ["storage_bytes"],
+  start: "2026-06-05T00:00:00Z",
+  period: 3600,
+});
+
+for (const point of usage["storage_bytes"] ?? []) {
+  console.log(point.timestamp, point.value);
+}
+
+// usage for a single inbox (storage, messages, threads)
+const inboxUsage = await client.inboxes.metrics.usage("support@agentmail.to");
+
+// event counts now live at /metrics/events
+const events = await client.metrics.events({
+  eventTypes: ["message.sent", "message.bounced"],
+  period: 3600,
+});
+```
+
+</CodeBlocks>
+
+<Note>
+  Check out the [Metrics API reference](https://docs.agentmail.to/api-reference/metrics) for full parameter details.
+</Note>

--- a/fern/changelog/2026-06-12.mdx
+++ b/fern/changelog/2026-06-12.mdx
@@ -20,7 +20,7 @@ You can now track cumulative usage over time. The new usage endpoint returns run
 - **Bucketing**: `period` sets the bucket size in seconds. The range divided by `period` must not exceed 1000 buckets — narrow the range or coarsen the period for fine-grained series.
 
 **Changes:**
-- `GET /v0/metrics` (and its pod/inbox variants) is replaced by `/metrics/events`. The old path still responds, so existing clients keep working, but it's removed from the docs and SDKs — use `client.metrics.events()` in place of `client.metrics.query()`.
+- `GET /v0/metrics` (and its pod/inbox variants) is replaced by `/metrics/events`. The old path still responds, so existing clients keep working, but it's removed from the docs and SDKs — use `client.metrics.queryEvents()` in place of `client.metrics.query()`.
 - Metric queries now clamp a future `end` to the current time instead of returning phantom future points, and `period`/`limit` must be whole numbers.
 - The documented metric event types now match what the API accepts: added `message.received.spam`, `message.received.blocked`, `message.received.unauthenticated`, and `domain.verified`; removed `message.delayed`, which the API never accepted.
 
@@ -40,7 +40,7 @@ from agentmail import AgentMail
 client = AgentMail(api_key="your-api-key")
 
 # storage growth for the last week, one point per hour
-usage = client.metrics.usage(
+usage = client.metrics.query_usage(
     usage_types=["storage_bytes"],
     start="2026-06-05T00:00:00Z",
     period=3600,
@@ -50,10 +50,10 @@ for point in usage["storage_bytes"]:
     print(point.timestamp, point.value)
 
 # usage for a single inbox (storage, messages, threads)
-inbox_usage = client.inboxes.metrics.usage(inbox_id="support@agentmail.to")
+inbox_usage = client.inboxes.metrics.query_usage(inbox_id="support@agentmail.to")
 
 # event counts now live at /metrics/events
-events = client.metrics.events(
+events = client.metrics.query_events(
     event_types=["message.sent", "message.bounced"],
     period=3600,
 )
@@ -65,7 +65,7 @@ import { AgentMailClient } from "agentmail";
 const client = new AgentMailClient({ apiKey: "your-api-key" });
 
 // storage growth for the last week, one point per hour
-const usage = await client.metrics.usage({
+const usage = await client.metrics.queryUsage({
   usageTypes: ["storage_bytes"],
   start: "2026-06-05T00:00:00Z",
   period: 3600,
@@ -76,10 +76,10 @@ for (const point of usage["storage_bytes"] ?? []) {
 }
 
 // usage for a single inbox (storage, messages, threads)
-const inboxUsage = await client.inboxes.metrics.usage("support@agentmail.to");
+const inboxUsage = await client.inboxes.metrics.queryUsage("support@agentmail.to");
 
 // event counts now live at /metrics/events
-const events = await client.metrics.events({
+const events = await client.metrics.queryEvents({
   eventTypes: ["message.sent", "message.bounced"],
   period: 3600,
 });

--- a/fern/definition/inboxes/metrics.yml
+++ b/fern/definition/inboxes/metrics.yml
@@ -13,17 +13,23 @@ service:
   auth: true
 
   endpoints:
-    query:
+    events:
       method: GET
-      path: ""
-      display-name: Query Metrics
+      path: /events
+      display-name: Query Events
       docs: |
+        Counts of email events (sent, delivered, bounced, etc.) over time for
+        the inbox. Defaults to the last 24 hours; `start` must be within the
+        last 90 days, and a future `end` is clamped to now. Omit `period` for
+        individual event counts, or set it to sum counts into buckets of that
+        many seconds.
+
         **CLI:**
         ```bash
         agentmail inboxes:metrics query --inbox-id <inbox_id>
         ```
       request:
-        name: QueryMetricsRequest
+        name: QueryEventsRequest
         query-parameters:
           event_types: optional<metrics.MetricEventTypes>
           start: optional<metrics.Start>
@@ -32,5 +38,30 @@ service:
           limit: optional<metrics.MetricLimit>
           descending: optional<metrics.Descending>
       response: metrics.QueryMetricsResponse
+      errors:
+        - global.ValidationError
+
+    usage:
+      method: GET
+      path: /usage
+      display-name: Query Usage
+      docs: |
+        Cumulative usage series for the inbox. Each point is the running total
+        of the usage type at that timestamp, not the change within the bucket.
+        Inbox-scoped queries carry `storage_bytes`, `message_count`, and
+        `thread_count`; requested types that don't apply to the scope are
+        ignored. Defaults to the last 24 hours; `start` must be within the
+        last 90 days, and a future `end` is clamped to now. The range divided
+        by `period` must not exceed 1000 buckets.
+      request:
+        name: QueryUsageRequest
+        query-parameters:
+          usage_types: optional<metrics.UsageTypes>
+          start: optional<metrics.Start>
+          end: optional<metrics.End>
+          period: optional<metrics.Period>
+          limit: optional<metrics.MetricLimit>
+          descending: optional<metrics.Descending>
+      response: metrics.QueryUsageResponse
       errors:
         - global.ValidationError

--- a/fern/definition/inboxes/metrics.yml
+++ b/fern/definition/inboxes/metrics.yml
@@ -13,7 +13,7 @@ service:
   auth: true
 
   endpoints:
-    events:
+    queryEvents:
       method: GET
       path: /events
       display-name: Query Events
@@ -41,7 +41,7 @@ service:
       errors:
         - global.ValidationError
 
-    usage:
+    queryUsage:
       method: GET
       path: /usage
       display-name: Query Usage

--- a/fern/definition/metrics.yml
+++ b/fern/definition/metrics.yml
@@ -5,22 +5,30 @@ imports:
   inboxes: inboxes/__package__.yml
 
 types:
+  # Mirrors EventType in events.yml (the API validates both against the same
+  # EventTypeSchema) — keep the two lists in sync.
   MetricEventType:
     enum:
+      - name: MESSAGE_RECEIVED
+        value: message.received
+      - name: MESSAGE_RECEIVED_SPAM
+        value: message.received.spam
+      - name: MESSAGE_RECEIVED_BLOCKED
+        value: message.received.blocked
+      - name: MESSAGE_RECEIVED_UNAUTHENTICATED
+        value: message.received.unauthenticated
       - name: MESSAGE_SENT
         value: message.sent
       - name: MESSAGE_DELIVERED
         value: message.delivered
       - name: MESSAGE_BOUNCED
         value: message.bounced
-      - name: MESSAGE_DELAYED
-        value: message.delayed
-      - name: MESSAGE_REJECTED
-        value: message.rejected
       - name: MESSAGE_COMPLAINED
         value: message.complained
-      - name: MESSAGE_RECEIVED
-        value: message.received
+      - name: MESSAGE_REJECTED
+        value: message.rejected
+      - name: DOMAIN_VERIFIED
+        value: domain.verified
     docs: Type of metric event.
 
   MetricEventTypes:
@@ -36,8 +44,8 @@ types:
     docs: End timestamp for the query.
 
   Period:
-    type: string
-    docs: Period in number of seconds for the query.
+    type: integer
+    docs: Size of each time bucket as a whole number of seconds, between 1 and 86400.
 
   MetricLimit:
     type: integer
@@ -60,23 +68,65 @@ types:
     type: map<MetricEventType, list<MetricBucket>>
     docs: Metrics grouped by event type.
 
+  UsageType:
+    enum:
+      - name: STORAGE_BYTES
+        value: storage_bytes
+      - name: MESSAGE_COUNT
+        value: message_count
+      - name: THREAD_COUNT
+        value: thread_count
+      - name: INBOX_COUNT
+        value: inbox_count
+      - name: POD_COUNT
+        value: pod_count
+      - name: DOMAIN_COUNT
+        value: domain_count
+    docs: |
+      Type of usage metric. Inbox-scoped queries carry `storage_bytes`,
+      `message_count`, and `thread_count`; pod-scoped queries add `inbox_count`
+      and `domain_count`; organization-scoped queries add `pod_count`.
+
+  UsageTypes:
+    type: list<UsageType>
+    docs: List of usage metric types to query. Omit to query every type valid for the scope.
+
+  UsagePoint:
+    properties:
+      timestamp:
+        type: datetime
+        docs: Timestamp of the point.
+      value:
+        type: long
+        docs: Cumulative value of the usage metric at the timestamp.
+
+  QueryUsageResponse:
+    type: map<UsageType, list<UsagePoint>>
+    docs: Cumulative usage series grouped by usage type.
+
 service:
   url: Http
   base-path: /metrics
   auth: true
 
   endpoints:
-    query:
+    events:
       method: GET
-      path: ""
-      display-name: Query Metrics
+      path: /events
+      display-name: Query Events
       docs: |
+        Counts of email events (sent, delivered, bounced, etc.) over time for
+        the organization. Defaults to the last 24 hours; `start` must be within
+        the last 90 days, and a future `end` is clamped to now. Omit `period`
+        for individual event counts, or set it to sum counts into buckets of
+        that many seconds.
+
         **CLI:**
         ```bash
         agentmail metrics list
         ```
       request:
-        name: QueryMetricsRequest
+        name: QueryEventsRequest
         query-parameters:
           event_types: optional<MetricEventTypes>
           start: optional<Start>
@@ -85,5 +135,28 @@ service:
           limit: optional<MetricLimit>
           descending: optional<Descending>
       response: QueryMetricsResponse
+      errors:
+        - global.ValidationError
+
+    usage:
+      method: GET
+      path: /usage
+      display-name: Query Usage
+      docs: |
+        Cumulative usage series for the organization. Each point is the running
+        total of the usage type at that timestamp, not the change within the
+        bucket. Defaults to the last 24 hours; `start` must be within the last
+        90 days, and a future `end` is clamped to now. The range divided by
+        `period` must not exceed 1000 buckets.
+      request:
+        name: QueryUsageRequest
+        query-parameters:
+          usage_types: optional<UsageTypes>
+          start: optional<Start>
+          end: optional<End>
+          period: optional<Period>
+          limit: optional<MetricLimit>
+          descending: optional<Descending>
+      response: QueryUsageResponse
       errors:
         - global.ValidationError

--- a/fern/definition/metrics.yml
+++ b/fern/definition/metrics.yml
@@ -110,7 +110,7 @@ service:
   auth: true
 
   endpoints:
-    events:
+    queryEvents:
       method: GET
       path: /events
       display-name: Query Events
@@ -138,7 +138,7 @@ service:
       errors:
         - global.ValidationError
 
-    usage:
+    queryUsage:
       method: GET
       path: /usage
       display-name: Query Usage

--- a/fern/definition/pods/metrics.yml
+++ b/fern/definition/pods/metrics.yml
@@ -13,17 +13,23 @@ service:
   auth: true
 
   endpoints:
-    query:
+    events:
       method: GET
-      path: ""
-      display-name: Query Metrics
+      path: /events
+      display-name: Query Events
       docs: |
+        Counts of email events (sent, delivered, bounced, etc.) over time for
+        the pod. Defaults to the last 24 hours; `start` must be within the last
+        90 days, and a future `end` is clamped to now. Omit `period` for
+        individual event counts, or set it to sum counts into buckets of that
+        many seconds.
+
         **CLI:**
         ```bash
         agentmail pods:metrics query --pod-id <pod_id>
         ```
       request:
-        name: QueryMetricsRequest
+        name: QueryEventsRequest
         query-parameters:
           event_types: optional<metrics.MetricEventTypes>
           start: optional<metrics.Start>
@@ -32,5 +38,30 @@ service:
           limit: optional<metrics.MetricLimit>
           descending: optional<metrics.Descending>
       response: metrics.QueryMetricsResponse
+      errors:
+        - global.ValidationError
+
+    usage:
+      method: GET
+      path: /usage
+      display-name: Query Usage
+      docs: |
+        Cumulative usage series for the pod. Each point is the running total of
+        the usage type at that timestamp, not the change within the bucket.
+        Pod-scoped queries carry every usage type except `pod_count`; requested
+        types that don't apply to the scope are ignored. Defaults to the last
+        24 hours; `start` must be within the last 90 days, and a future `end`
+        is clamped to now. The range divided by `period` must not exceed 1000
+        buckets.
+      request:
+        name: QueryUsageRequest
+        query-parameters:
+          usage_types: optional<metrics.UsageTypes>
+          start: optional<metrics.Start>
+          end: optional<metrics.End>
+          period: optional<metrics.Period>
+          limit: optional<metrics.MetricLimit>
+          descending: optional<metrics.Descending>
+      response: metrics.QueryUsageResponse
       errors:
         - global.ValidationError

--- a/fern/definition/pods/metrics.yml
+++ b/fern/definition/pods/metrics.yml
@@ -13,7 +13,7 @@ service:
   auth: true
 
   endpoints:
-    events:
+    queryEvents:
       method: GET
       path: /events
       display-name: Query Events
@@ -41,7 +41,7 @@ service:
       errors:
         - global.ValidationError
 
-    usage:
+    queryUsage:
       method: GET
       path: /usage
       display-name: Query Usage

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -130,7 +130,15 @@ redirects:
   - source: /v0/pods/pod_id/threads/thread_id
     destination: /api-reference/pods/threads/list
   - source: /v0/inboxes/:inbox_id/metrics
-    destination: /api-reference/inboxes/metrics/get
+    destination: /api-reference/inboxes/metrics/events
+
+  # Old bare-metrics endpoint pages (replaced by /metrics/events)
+  - source: /api-reference/metrics/query
+    destination: /api-reference/metrics/events
+  - source: /api-reference/inboxes/metrics/query
+    destination: /api-reference/inboxes/metrics/events
+  - source: /api-reference/pods/metrics/query
+    destination: /api-reference/pods/metrics/events
   - source: /v0/pods/:pod_id/drafts/:draft_id
     destination: /api-reference/pods/drafts/get
   - source: /v0/inboxes/inbox_id/messages/send

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -130,15 +130,15 @@ redirects:
   - source: /v0/pods/pod_id/threads/thread_id
     destination: /api-reference/pods/threads/list
   - source: /v0/inboxes/:inbox_id/metrics
-    destination: /api-reference/inboxes/metrics/events
+    destination: /api-reference/inboxes/metrics/query-events
 
   # Old bare-metrics endpoint pages (replaced by /metrics/events)
   - source: /api-reference/metrics/query
-    destination: /api-reference/metrics/events
+    destination: /api-reference/metrics/query-events
   - source: /api-reference/inboxes/metrics/query
-    destination: /api-reference/inboxes/metrics/events
+    destination: /api-reference/inboxes/metrics/query-events
   - source: /api-reference/pods/metrics/query
-    destination: /api-reference/pods/metrics/events
+    destination: /api-reference/pods/metrics/query-events
   - source: /v0/pods/:pod_id/drafts/:draft_id
     destination: /api-reference/pods/drafts/get
   - source: /v0/inboxes/inbox_id/messages/send


### PR DESCRIPTION
## What

Documents the metrics changes from [agentmail-api#358](https://github.com/agentmail-to/agentmail-api/pull/358) (the Fern follow-up it called out):

- **`GET /metrics/usage`** (+ `/pods/{pod_id}/…`, `/inboxes/{inbox_id}/…`): cumulative usage series per usage type (`storage_bytes`, `message_count`, `thread_count`, `inbox_count`, `domain_count`, `pod_count`). New `UsageType`/`UsagePoint`/`QueryUsageResponse` types; `value` is a `long` since storage bytes can exceed int32. Docs cover the cumulative semantics (running totals, not per-bucket deltas), per-scope field carve-outs, the 90-day retention floor, future-`end` clamping, and the 1000-bucket cap.
- **`GET /metrics/events`** (+ scoped variants): the canonical event-count path, same parameters and response as the old query endpoint. `period` is integer-typed (the API rejects fractional values).
- **Bare `GET /metrics` removed from the spec.** The API keeps the alias responding, so existing clients and SDKs keep working, but the next SDK release drops `client.metrics.query()` in favor of `client.metrics.queryEvents()`. Redirects added from the old `/api-reference/*/metrics/query` pages (and one pre-existing stale redirect destination fixed).
- **Endpoint names are `queryEvents`/`queryUsage`** to match the verb convention used across the spec (list, get, search, query) — SDK methods come out as `query_events`/`query_usage` in Python, `queryEvents`/`queryUsage` in TypeScript.
- **`MetricEventType` synced with the API's `EventTypeSchema`**: adds `message.received.spam`, `message.received.blocked`, `message.received.unauthenticated`, and `domain.verified`; removes `message.delayed`, which the API rejects — it never worked, so SDK code referencing it gets a compile error instead of a runtime 400.
- Changelog entry for 2026-06-12 with Python/TypeScript examples.

Deliberately not documented: the default usage bucket size (requested as a server-side change on [agentmail-api#367](https://github.com/agentmail-to/agentmail-api/pull/367)) — the docs say "defaults to the last 24 hours," which holds before and after that PR.

## Checks

- `npx fern check`: 0 errors; the 9 warnings are pre-existing (benign `/search` path-conflict warnings + the TEMPLATE.mdx one).
- Old endpoint page slugs verified against the live site before writing redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)