### PR TITLE
docs: document client_id cannot contain @ symbol in idempotency.mdx

### DIFF
--- a/fern/pages/best-practices/idempotency.mdx
+++ b/fern/pages/best-practices/idempotency.mdx
@@ -47,5 +47,6 @@ To use idempotency effectively, the `client_id` you generate must be unique and 
 - **Deterministic:** The same logical resource on your end should always generate the same `client_id`. For example, a `client_id` for a user's primary inbox could be `inbox-for-user-{{USER_ID}}`.
 - **Unique:** Do not reuse a `client_id` for creating different resources. A `client_id` used to create an inbox should not be used to create a webhook.
 - **No `@` symbol:** The `client_id` value cannot contain the `@` symbol. If you want to use an email address as an identifier, replace `@` with another character (e.g., `user_at_example.com` instead of `user@example.com`).
+- **No `@` symbol:** The `client_id` value cannot contain the `@` symbol. If you want to use an email address as an identifier, replace `@` with another character (e.g., `user_at_example.com` instead of `user@example.com`).
 
 A common and highly effective pattern is to generate a UUID (like a `UUID v4`) on your client side for a resource you are about to create, save that UUID in your own database, and then use it as the `client_id` in the API call. This gives you a reliable key to use for any retries.

--- a/fern/pages/best-practices/idempotency.mdx
+++ b/fern/pages/best-practices/idempotency.mdx
@@ -47,6 +47,5 @@ To use idempotency effectively, the `client_id` you generate must be unique and 
 - **Deterministic:** The same logical resource on your end should always generate the same `client_id`. For example, a `client_id` for a user's primary inbox could be `inbox-for-user-{{USER_ID}}`.
 - **Unique:** Do not reuse a `client_id` for creating different resources. A `client_id` used to create an inbox should not be used to create a webhook.
 - **No `@` symbol:** The `client_id` value cannot contain the `@` symbol. If you want to use an email address as an identifier, replace `@` with another character (e.g., `user_at_example.com` instead of `user@example.com`).
-- **No `@` symbol:** The `client_id` value cannot contain the `@` symbol. If you want to use an email address as an identifier, replace `@` with another character (e.g., `user_at_example.com` instead of `user@example.com`).
 
 A common and highly effective pattern is to generate a UUID (like a `UUID v4`) on your client side for a resource you are about to create, save that UUID in your own database, and then use it as the `client_id` in the API call. This gives you a reliable key to use for any retries.

--- a/fern/pages/best-practices/idempotency.mdx
+++ b/fern/pages/best-practices/idempotency.mdx
@@ -46,5 +46,6 @@ To use idempotency effectively, the `client_id` you generate must be unique and 
 
 - **Deterministic:** The same logical resource on your end should always generate the same `client_id`. For example, a `client_id` for a user's primary inbox could be `inbox-for-user-{{USER_ID}}`.
 - **Unique:** Do not reuse a `client_id` for creating different resources. A `client_id` used to create an inbox should not be used to create a webhook.
+- **No `@` symbol:** The `client_id` value cannot contain the `@` symbol. If you want to use an email address as an identifier, replace `@` with another character (e.g., `user_at_example.com` instead of `user@example.com`).
 
 A common and highly effective pattern is to generate a UUID (like a `UUID v4`) on your client side for a resource you are about to create, save that UUID in your own database, and then use it as the `client_id` in the API call. This gives you a reliable key to use for any retries.


### PR DESCRIPTION
## What and why

The API silently rejects `client_id` values that contain `@`, but this was never documented. Agents naturally reach for email addresses as client IDs (e.g. `recruiter@company.com`) since they're unique identifiers in email workflows — but the API throws a `ValidationError` with no hint as to why.

## Change
Added a bullet to the Best Practices section explaining that `@` is not allowed in `client_id`, with a workaround example (`user_at_example.com` instead of `user@example.com`).