### PR TITLE
docs: add draft reply/forward and pod/inbox-scoped webhook endpoints

### DIFF
--- a/fern/changelog/2026-06-25-webhooks.mdx
+++ b/fern/changelog/2026-06-25-webhooks.mdx
@@ -1,0 +1,58 @@
+---
+tags: ["webhooks", "pods-api", "new-feature"]
+---
+
+## Summary
+
+You can now create and manage webhooks scoped to a single pod or inbox from dedicated endpoints, instead of only filtering an organization-level webhook with `pod_ids` / `inbox_ids`. The scope comes from the path, so pod- and inbox-scoped API keys can manage just their own webhooks.
+
+### What's new?
+
+**New endpoints:**
+- `GET|POST /v0/pods/:pod_id/webhooks` and `GET|PATCH|DELETE /v0/pods/:pod_id/webhooks/:webhook_id` - Manage webhooks scoped to a pod.
+- `GET|POST /v0/inboxes/:inbox_id/webhooks` and `GET|PATCH|DELETE /v0/inboxes/:inbox_id/webhooks/:webhook_id` - Manage webhooks scoped to an inbox.
+
+**Behavior:**
+- A **pod-scoped** webhook receives events for the whole pod, and can be narrowed to specific inboxes in the pod with `inbox_ids`. You don't pass `pod_ids` — the pod is the path.
+- An **inbox-scoped** webhook is fixed to that inbox; only its `event_types` can be changed.
+- A scoped webhook must always keep at least one pod or inbox subscription.
+
+### Use cases
+
+Build agents that:
+- Give each tenant's pod-scoped API key its own webhook, isolated from other tenants
+- Register a webhook for a single high-volume inbox without touching org-wide delivery
+- Let an inbox-scoped key manage only its own event subscriptions
+
+<CodeBlocks>
+
+```python title="Python"
+from agentmail import AgentMail
+
+client = AgentMail(api_key="your-api-key")
+
+# webhook scoped to a single pod
+client.pods.webhooks.create(
+    pod_id="pod_abc123",
+    url="https://your-server.com/webhooks",
+    event_types=["message.received"],
+)
+```
+
+```typescript title="TypeScript"
+import { AgentMailClient } from "agentmail";
+
+const client = new AgentMailClient({ apiKey: "your-api-key" });
+
+// webhook scoped to a single pod
+await client.pods.webhooks.create("pod_abc123", {
+  url: "https://your-server.com/webhooks",
+  eventTypes: ["message.received"],
+});
+```
+
+</CodeBlocks>
+
+<Note>
+  See [Scoping a webhook to a pod or inbox](https://docs.agentmail.to/webhooks-overview) for details.
+</Note>

--- a/fern/changelog/2026-06-25.mdx
+++ b/fern/changelog/2026-06-25.mdx
@@ -1,0 +1,70 @@
+---
+tags: ["drafts-api", "messages-api", "new-feature"]
+---
+
+## Summary
+
+Agents can now create reply, reply-all, and forward drafts directly from a message, instead of rebuilding the recipients, subject, and threading by hand. The draft is saved rather than sent, so a human can review it before it goes out — then send it with `Send Draft`. This makes human-in-the-loop review and scheduled follow-ups a first-class part of the reply flow.
+
+### What's new?
+
+**New endpoints:**
+- `POST /v0/inboxes/:inbox_id/messages/:message_id/draft-reply` - Create a draft replying to the sender. Set `reply_all` to address the whole thread.
+- `POST /v0/inboxes/:inbox_id/messages/:message_id/draft-reply-all` - Create a draft replying to everyone on the thread.
+- `POST /v0/inboxes/:inbox_id/messages/:message_id/draft-forward` - Create a draft forwarding the message.
+
+**New features:**
+- **Derived from the source message**: recipients, subject, and threading (`in_reply_to` / `references`) are taken from the original message, so you only supply your note.
+- **Forwards**: the original body and attachments are merged in at send time; recipients are optional, so a forward draft can be saved now and addressed later.
+- **Composable**: pass `send_at` to schedule the draft, or review and send it later with `inboxes.drafts.send`.
+
+**Changes:**
+- Draft responses now include `forward_of`, the ID of the message a forward draft was created from.
+
+### Use cases
+
+Build agents that:
+- Draft a reply for human approval before anything leaves the inbox
+- Forward a flagged message to a teammate, then send once reviewed
+- Schedule a reply-all for the recipient's business hours
+- Prepare a response while still gathering data, and finalize it later
+
+<CodeBlocks>
+
+```python title="Python"
+from agentmail import AgentMail
+
+client = AgentMail(api_key="your-api-key")
+
+# create a reply draft from a received message
+draft = client.inboxes.messages.draft_reply(
+    inbox_id="agent@agentmail.to",
+    message_id="<message-id@agentmail.to>",
+    text="Thanks — looping in my manager for approval.",
+)
+
+# review, then send when ready
+client.inboxes.drafts.send(inbox_id="agent@agentmail.to", draft_id=draft.draft_id)
+```
+
+```typescript title="TypeScript"
+import { AgentMailClient } from "agentmail";
+
+const client = new AgentMailClient({ apiKey: "your-api-key" });
+
+// create a reply draft from a received message
+const draft = await client.inboxes.messages.draftReply(
+  "agent@agentmail.to",
+  "<message-id@agentmail.to>",
+  { text: "Thanks — looping in my manager for approval." }
+);
+
+// review, then send when ready
+await client.inboxes.drafts.send("agent@agentmail.to", draft.draftId);
+```
+
+</CodeBlocks>
+
+<Note>
+  See the [Drafts guide](https://docs.agentmail.to/core-concepts/drafts) for the full reply and forward flow.
+</Note>

--- a/fern/definition/drafts.yml
+++ b/fern/definition/drafts.yml
@@ -59,6 +59,14 @@ types:
     type: string
     docs: ID of message being replied to.
 
+  DraftForwardOf:
+    type: string
+    docs: ID of message being forwarded.
+
+  DraftReplyAll:
+    type: boolean
+    docs: Reply to all recipients of the original message.
+
   DraftSendStatus:
     enum:
       - scheduled
@@ -87,6 +95,7 @@ types:
       preview: optional<DraftPreview>
       attachments: optional<DraftAttachments>
       in_reply_to: optional<DraftInReplyTo>
+      forward_of: optional<DraftForwardOf>
       send_status: optional<DraftSendStatus>
       send_at: optional<DraftSendAt>
       updated_at: DraftUpdatedAt
@@ -107,6 +116,7 @@ types:
       html: optional<DraftHtml>
       attachments: optional<DraftAttachments>
       in_reply_to: optional<DraftInReplyTo>
+      forward_of: optional<DraftForwardOf>
       references:
         type: optional<list<string>>
         docs: IDs of previous messages in thread.
@@ -153,6 +163,66 @@ types:
       text: optional<DraftText>
       html: optional<DraftHtml>
       send_at: optional<DraftSendAt>
+
+  CreateDraftReplyRequest:
+    docs: |
+      Body for creating a draft that replies to a message. `in_reply_to`,
+      `references`, and the subject are derived from the source message. Set
+      `reply_all` to address the whole thread (you cannot then also pass `to`,
+      `cc`, or `bcc`).
+    properties:
+      labels: optional<DraftLabels>
+      reply_to: optional<DraftReplyTo>
+      to: optional<DraftTo>
+      cc: optional<DraftCc>
+      bcc: optional<DraftBcc>
+      reply_all: optional<DraftReplyAll>
+      subject: optional<DraftSubject>
+      text: optional<DraftText>
+      html: optional<DraftHtml>
+      attachments:
+        type: optional<list<attachments.SendAttachment>>
+        docs: Attachments to include in draft.
+      send_at: optional<DraftSendAt>
+      client_id: optional<DraftClientId>
+
+  CreateDraftReplyAllRequest:
+    docs: |
+      Body for creating a draft that replies to the whole thread. Recipients,
+      `in_reply_to`, `references`, and the subject are always derived from the
+      source message, so `to`, `cc`, and `bcc` are not accepted.
+    properties:
+      labels: optional<DraftLabels>
+      reply_to: optional<DraftReplyTo>
+      subject: optional<DraftSubject>
+      text: optional<DraftText>
+      html: optional<DraftHtml>
+      attachments:
+        type: optional<list<attachments.SendAttachment>>
+        docs: Attachments to include in draft.
+      send_at: optional<DraftSendAt>
+      client_id: optional<DraftClientId>
+
+  CreateDraftForwardRequest:
+    docs: |
+      Body for creating a draft that forwards a message. The subject and
+      threading are derived from the source message, whose body and attachments
+      are merged in at send time. Recipients are optional, so a forward draft can
+      be saved without an address and addressed later.
+    properties:
+      labels: optional<DraftLabels>
+      reply_to: optional<DraftReplyTo>
+      to: optional<DraftTo>
+      cc: optional<DraftCc>
+      bcc: optional<DraftBcc>
+      subject: optional<DraftSubject>
+      text: optional<DraftText>
+      html: optional<DraftHtml>
+      attachments:
+        type: optional<list<attachments.SendAttachment>>
+        docs: Attachments to include in draft.
+      send_at: optional<DraftSendAt>
+      client_id: optional<DraftClientId>
 
 service:
   url: Http

--- a/fern/definition/inboxes/__package__.yml
+++ b/fern/definition/inboxes/__package__.yml
@@ -4,6 +4,7 @@ navigation:
   - threads.yml
   - messages.yml
   - drafts.yml
+  - webhooks.yml
   - lists.yml
   - metrics.yml
   - events.yml

--- a/fern/definition/inboxes/messages.yml
+++ b/fern/definition/inboxes/messages.yml
@@ -4,6 +4,7 @@ imports:
   global: ../__package__.yml
   inboxes: __package__.yml
   messages: ../messages.yml
+  drafts: ../drafts.yml
   attachments: ../attachments.yml
 
 service:
@@ -264,3 +265,66 @@ service:
         - global.ValidationError
         - global.NotFoundError
         - messages.MessageRejectedError
+
+    draft-reply:
+      method: POST
+      path: /{message_id}/draft-reply
+      display-name: Create Draft Reply
+      docs: |
+        Create a draft that replies to a message instead of sending it. The
+        recipients, subject, and threading are derived from the source message.
+        Send it later with `Send Draft`.
+
+        **CLI:**
+        ```bash
+        agentmail inboxes:messages draft-reply --inbox-id <inbox_id> --message-id <message_id> --text "Reply text"
+        ```
+      path-parameters:
+        message_id: messages.MessageId
+      request: drafts.CreateDraftReplyRequest
+      response: drafts.Draft
+      errors:
+        - global.ValidationError
+        - global.NotFoundError
+
+    draft-reply-all:
+      method: POST
+      path: /{message_id}/draft-reply-all
+      display-name: Create Draft Reply All
+      docs: |
+        Create a draft that replies to every recipient of a message instead of
+        sending it. Recipients, subject, and threading are derived from the
+        source message. Send it later with `Send Draft`.
+
+        **CLI:**
+        ```bash
+        agentmail inboxes:messages draft-reply-all --inbox-id <inbox_id> --message-id <message_id> --text "Reply text"
+        ```
+      path-parameters:
+        message_id: messages.MessageId
+      request: drafts.CreateDraftReplyAllRequest
+      response: drafts.Draft
+      errors:
+        - global.ValidationError
+        - global.NotFoundError
+
+    draft-forward:
+      method: POST
+      path: /{message_id}/draft-forward
+      display-name: Create Draft Forward
+      docs: |
+        Create a draft that forwards a message instead of sending it. The subject
+        and threading are derived from the source message, whose body and
+        attachments are merged in at send time. Send it later with `Send Draft`.
+
+        **CLI:**
+        ```bash
+        agentmail inboxes:messages draft-forward --inbox-id <inbox_id> --message-id <message_id> --to recipient@example.com
+        ```
+      path-parameters:
+        message_id: messages.MessageId
+      request: drafts.CreateDraftForwardRequest
+      response: drafts.Draft
+      errors:
+        - global.ValidationError
+        - global.NotFoundError

--- a/fern/definition/inboxes/webhooks.yml
+++ b/fern/definition/inboxes/webhooks.yml
@@ -1,0 +1,93 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
+
+imports:
+  global: ../__package__.yml
+  inboxes: __package__.yml
+  webhooks: ../webhooks/__package__.yml
+
+service:
+  url: Http
+  base-path: /inboxes/{inbox_id}/webhooks
+  path-parameters:
+    inbox_id: inboxes.InboxId
+  auth: true
+
+  endpoints:
+    list:
+      method: GET
+      path: ""
+      display-name: List Webhooks
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:webhooks list --inbox-id <inbox_id>
+        ```
+      request:
+        name: InboxListWebhooksRequest
+        query-parameters:
+          limit: optional<global.Limit>
+          page_token: optional<global.PageToken>
+          ascending: optional<global.Ascending>
+      response: webhooks.ListWebhooksResponse
+
+    get:
+      method: GET
+      path: /{webhook_id}
+      display-name: Get Webhook
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:webhooks get --inbox-id <inbox_id> --webhook-id <webhook_id>
+        ```
+      path-parameters:
+        webhook_id: webhooks.WebhookId
+      response: webhooks.Webhook
+      errors:
+        - global.NotFoundError
+
+    create:
+      method: POST
+      path: ""
+      display-name: Create Webhook
+      docs: |
+        Create a webhook scoped to this inbox.
+
+        **CLI:**
+        ```bash
+        agentmail inboxes:webhooks create --inbox-id <inbox_id> --url https://example.com/webhook --event-type message.received
+        ```
+      request: webhooks.CreateInboxWebhookRequest
+      response: webhooks.Webhook
+      errors:
+        - global.ValidationError
+
+    update:
+      method: PATCH
+      path: /{webhook_id}
+      display-name: Update Webhook
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:webhooks update --inbox-id <inbox_id> --webhook-id <webhook_id> --event-type message.received
+        ```
+      path-parameters:
+        webhook_id: webhooks.WebhookId
+      request: webhooks.UpdateInboxWebhookRequest
+      response: webhooks.Webhook
+      errors:
+        - global.NotFoundError
+        - global.ValidationError
+
+    delete:
+      method: DELETE
+      path: /{webhook_id}
+      display-name: Delete Webhook
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail inboxes:webhooks delete --inbox-id <inbox_id> --webhook-id <webhook_id>
+        ```
+      path-parameters:
+        webhook_id: webhooks.WebhookId
+      errors:
+        - global.NotFoundError

--- a/fern/definition/pods/__package__.yml
+++ b/fern/definition/pods/__package__.yml
@@ -4,6 +4,7 @@ navigation:
   - inboxes.yml
   - threads.yml
   - drafts.yml
+  - webhooks.yml
   - domains.yml
   - lists.yml
   - metrics.yml

--- a/fern/definition/pods/webhooks.yml
+++ b/fern/definition/pods/webhooks.yml
@@ -1,0 +1,93 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
+
+imports:
+  global: ../__package__.yml
+  pods: __package__.yml
+  webhooks: ../webhooks/__package__.yml
+
+service:
+  url: Http
+  base-path: /pods/{pod_id}/webhooks
+  path-parameters:
+    pod_id: pods.PodId
+  auth: true
+
+  endpoints:
+    list:
+      method: GET
+      path: ""
+      display-name: List Webhooks
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:webhooks list --pod-id <pod_id>
+        ```
+      request:
+        name: PodListWebhooksRequest
+        query-parameters:
+          limit: optional<global.Limit>
+          page_token: optional<global.PageToken>
+          ascending: optional<global.Ascending>
+      response: webhooks.ListWebhooksResponse
+
+    get:
+      method: GET
+      path: /{webhook_id}
+      display-name: Get Webhook
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:webhooks get --pod-id <pod_id> --webhook-id <webhook_id>
+        ```
+      path-parameters:
+        webhook_id: webhooks.WebhookId
+      response: webhooks.Webhook
+      errors:
+        - global.NotFoundError
+
+    create:
+      method: POST
+      path: ""
+      display-name: Create Webhook
+      docs: |
+        Create a webhook scoped to this pod.
+
+        **CLI:**
+        ```bash
+        agentmail pods:webhooks create --pod-id <pod_id> --url https://example.com/webhook --event-type message.received
+        ```
+      request: webhooks.CreatePodWebhookRequest
+      response: webhooks.Webhook
+      errors:
+        - global.ValidationError
+
+    update:
+      method: PATCH
+      path: /{webhook_id}
+      display-name: Update Webhook
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:webhooks update --pod-id <pod_id> --webhook-id <webhook_id> --add-inbox-id <inbox_id>
+        ```
+      path-parameters:
+        webhook_id: webhooks.WebhookId
+      request: webhooks.UpdatePodWebhookRequest
+      response: webhooks.Webhook
+      errors:
+        - global.NotFoundError
+        - global.ValidationError
+
+    delete:
+      method: DELETE
+      path: /{webhook_id}
+      display-name: Delete Webhook
+      docs: |
+        **CLI:**
+        ```bash
+        agentmail pods:webhooks delete --pod-id <pod_id> --webhook-id <webhook_id>
+        ```
+      path-parameters:
+        webhook_id: webhooks.WebhookId
+      errors:
+        - global.NotFoundError

--- a/fern/definition/webhooks/__package__.yml
+++ b/fern/definition/webhooks/__package__.yml
@@ -48,20 +48,63 @@ types:
         type: list<Webhook>
         docs: Ordered by `created_at` descending.
 
-  CreateWebhookRequest:
+  # Shared event-type field docs, referenced by every create/update request below so the
+  # text lives in one place.
+  CreateWebhookEventTypes:
+    type: events.EventTypes
+    docs: |
+      Full list of event types this webhook should receive. At least one type is required. Send every type you
+      want in this array (not incremental). See [Webhooks overview](https://docs.agentmail.to/webhooks-overview)
+      for spam, blocked, and unauthenticated events and required permissions.
+
+  UpdateWebhookEventTypes:
+    type: events.EventTypes
+    docs: |
+      When you send a non-empty list, it replaces the webhook's subscribed event types in full (the same
+      "set the list" behavior as create). It is not a merge or diff: include every event type you want after
+      the update. Sending a one-element array means the webhook will only receive that one type afterward.
+      Omit this field or send an empty array to leave event types unchanged. Clearing all types with an empty
+      list is not supported. Subscribing to `message.received.spam`, `message.received.blocked`, or
+      `message.received.unauthenticated` requires the matching label permission on the API key.
+
+  # Create requests. The inbox-scoped body is the smallest shape (the inbox comes from the path);
+  # each wider scope extends the previous one, adding only the channel fields it additionally accepts
+  # (pod adds inbox_ids; organization adds pod_ids).
+  CreateInboxWebhookRequest:
+    docs: |
+      Create a webhook scoped to an inbox. The inbox comes from the path, so `inbox_ids` and `pod_ids`
+      are not accepted.
     properties:
       url: Url
-      event_types:
-        type: events.EventTypes
-        docs: |
-          Full list of event types this webhook should receive. At least one type is required. Send every type you
-          want in this array (not incremental). See [Webhooks overview](https://docs.agentmail.to/webhooks-overview)
-          for spam, blocked, and unauthenticated events and required permissions.
-      pod_ids: optional<events.PodIds>
-      inbox_ids: optional<events.InboxIds>
+      event_types: CreateWebhookEventTypes
       client_id: optional<ClientId>
 
-  UpdateWebhookRequest:
+  CreatePodWebhookRequest:
+    docs: |
+      Create a webhook scoped to a pod. The pod comes from the path, so `pod_ids` is not accepted.
+      Optionally pass `inbox_ids` to narrow the webhook to specific inboxes within the pod; omit to
+      receive events for the whole pod.
+    extends: CreateInboxWebhookRequest
+    properties:
+      inbox_ids: optional<events.InboxIds>
+
+  CreateWebhookRequest:
+    extends: CreatePodWebhookRequest
+    properties:
+      pod_ids: optional<events.PodIds>
+
+  # Update requests. `event_types` is editable at every scope; wider scopes can additionally
+  # change which channels (inboxes, then pods) the webhook is subscribed to.
+  UpdateInboxWebhookRequest:
+    docs: Update an inbox-scoped webhook. It is fixed to its inbox, so only `event_types` can change.
+    properties:
+      event_types: optional<UpdateWebhookEventTypes>
+
+  UpdatePodWebhookRequest:
+    docs: |
+      Update a pod-scoped webhook. You can adjust which inboxes within the pod it listens to and replace
+      its `event_types`, but not the pod scope itself.
+    extends: UpdateInboxWebhookRequest
     properties:
       add_inbox_ids:
         type: optional<events.InboxIds>
@@ -69,21 +112,16 @@ types:
       remove_inbox_ids:
         type: optional<events.InboxIds>
         docs: Inbox IDs to unsubscribe from the webhook.
+
+  UpdateWebhookRequest:
+    extends: UpdatePodWebhookRequest
+    properties:
       add_pod_ids:
         type: optional<events.PodIds>
         docs: Pod IDs to subscribe to the webhook.
       remove_pod_ids:
         type: optional<events.PodIds>
         docs: Pod IDs to unsubscribe from the webhook.
-      event_types:
-        type: optional<events.EventTypes>
-        docs: |
-          When you send a non-empty list, it replaces the webhook's subscribed event types in full (the same
-          "set the list" behavior as create). It is not a merge or diff: include every event type you want after
-          the update. Sending a one-element array means the webhook will only receive that one type afterward.
-          Omit this field or send an empty array to leave event types unchanged. Clearing all types with an empty
-          list is not supported. Subscribing to `message.received.spam`, `message.received.blocked`, or
-          `message.received.unauthenticated` requires the matching label permission on the API key.
 
 service:
   url: Http

--- a/fern/pages/core-concepts/drafts.mdx
+++ b/fern/pages/core-concepts/drafts.mdx
@@ -128,6 +128,70 @@ agentmail inboxes:drafts send \
 
 Note that now we access it by message_id now because now its a message!!
 
+## Reply and Forward Drafts
+
+Instead of building a reply or forward by hand, you can create a `Draft` directly from an existing `Message`. AgentMail derives the recipients, subject, and threading from the source message, so a human can review the prepared reply before it goes out. These create a `Draft` (they do not send) — send it later with `inboxes.drafts.send`.
+
+- `inboxes.messages.draft_reply` — reply to the original sender. Set `reply_all=True` to address the whole thread.
+- `inboxes.messages.draft_reply_all` — reply to everyone on the thread (recipients are always derived from the source message).
+- `inboxes.messages.draft_forward` — forward the message. The original body and attachments are merged in at send time.
+
+<CodeBlocks>
+```python title="Python"
+# create a draft reply to the sender of a received message
+draft = client.inboxes.messages.draft_reply(
+    inbox_id="agent@domain.com",
+    message_id="<message-id@domain.com>",
+    text="Thanks — looping in my manager for approval.",
+)
+
+# forward a message as a draft for later review
+forward = client.inboxes.messages.draft_forward(
+    inbox_id="agent@domain.com",
+    message_id="<message-id@domain.com>",
+    to=["teammate@example.com"],
+    text="See below — can you take this one?",
+)
+
+# review, then send when ready
+client.inboxes.drafts.send(inbox_id="agent@domain.com", draft_id=draft.draft_id)
+```
+
+```typescript title="TypeScript"
+// create a draft reply to the sender of a received message
+const draft = await client.inboxes.messages.draftReply(
+  "agent@domain.com",
+  "<message-id@domain.com>",
+  { text: "Thanks — looping in my manager for approval." }
+);
+
+// forward a message as a draft for later review
+const forward = await client.inboxes.messages.draftForward(
+  "agent@domain.com",
+  "<message-id@domain.com>",
+  { to: ["teammate@example.com"], text: "See below — can you take this one?" }
+);
+
+// review, then send when ready
+await client.inboxes.drafts.send("agent@domain.com", draft.draftId);
+```
+
+```bash title="CLI"
+# create a draft reply to a message
+agentmail inboxes:messages draft-reply \
+  --inbox-id agent@domain.com \
+  --message-id "<message-id@domain.com>" \
+  --text "Thanks — looping in my manager for approval."
+
+# forward a message as a draft
+agentmail inboxes:messages draft-forward \
+  --inbox-id agent@domain.com \
+  --message-id "<message-id@domain.com>" \
+  --to teammate@example.com \
+  --text "See below — can you take this one?"
+```
+</CodeBlocks>
+
 ## Scheduled Sending
 
 You can schedule a `Draft` to be sent automatically at a future time by passing the `send_at` field when creating or updating a `Draft`. AgentMail will automatically send it at the specified time—no cron jobs or polling required.
@@ -458,6 +522,9 @@ Copy one of the blocks below into Cursor or Claude for complete Drafts API knowl
 
   API reference:
   - inboxes.drafts.create(inbox_id, to, subject?, text?, html?, cc?, bcc?, reply_to?, attachments?, send_at?)
+  - inboxes.messages.draft_reply(inbox_id, message_id, text?, html?, reply_all?, ...) — reply draft from a message
+  - inboxes.messages.draft_reply_all(inbox_id, message_id, text?, html?, ...) — reply-all draft from a message
+  - inboxes.messages.draft_forward(inbox_id, message_id, to?, text?, html?, ...) — forward draft from a message
   - inboxes.drafts.get(inbox_id, draft_id)
   - inboxes.drafts.update(inbox_id, draft_id, to?, subject?, text?, html?, send_at?, ...)
   - inboxes.drafts.send(inbox_id, draft_id) — converts to Message, deletes draft
@@ -506,6 +573,9 @@ Copy one of the blocks below into Cursor or Claude for complete Drafts API knowl
    *
    * API reference:
    * - inboxes.drafts.create(inboxId, { to, subject?, text?, html?, cc?, bcc?, replyTo?, attachments?, sendAt? })
+   * - inboxes.messages.draftReply(inboxId, messageId, { text?, html?, replyAll?, ... }) — reply draft from a message
+   * - inboxes.messages.draftReplyAll(inboxId, messageId, { text?, html?, ... }) — reply-all draft from a message
+   * - inboxes.messages.draftForward(inboxId, messageId, { to?, text?, html?, ... }) — forward draft from a message
    * - inboxes.drafts.get(inboxId, draftId)
    * - inboxes.drafts.update(inboxId, draftId, { to?, subject?, text?, html?, sendAt?, ... })
    * - inboxes.drafts.send(inboxId, draftId) — converts to Message, deletes draft

--- a/fern/pages/webhooks/webhooks-overview.mdx
+++ b/fern/pages/webhooks/webhooks-overview.mdx
@@ -49,6 +49,59 @@ When you [update a webhook](https://docs.agentmail.to/api-reference/webhooks/upd
 
 Subscribing to `message.received.spam`, `message.received.blocked`, or `message.received.unauthenticated` on update still requires the same [label permissions](/core-concepts/permissions) as on create.
 
+## Scoping a webhook to a pod or inbox
+
+By default a webhook is registered at the organization level. You can scope it to a single [pod](/core-concepts/pods) or inbox in two equivalent ways:
+
+- **From the organization endpoint:** pass `pod_ids` or `inbox_ids` when you `webhooks.create` (and add or remove them later with `add_pod_ids` / `add_inbox_ids` on update).
+- **From the scoped endpoints:** call `pods.webhooks.create(pod_id, ...)` or `inboxes.webhooks.create(inbox_id, ...)`. The pod or inbox comes from the path, so you don't pass `pod_ids` / `inbox_ids` in the body. A pod-scoped webhook receives events for the whole pod (optionally narrowed to specific inboxes with `inbox_ids`); an inbox-scoped webhook is fixed to that inbox and can only change its `event_types`.
+
+The scoped endpoints are the natural fit for [pod- or inbox-scoped API keys](/core-concepts/permissions): such a key can manage only its own webhooks, and a scoped webhook must always keep at least one pod or inbox subscription.
+
+<CodeBlocks>
+```python title="Python"
+# webhook scoped to a single pod
+client.pods.webhooks.create(
+    pod_id="pod_abc123",
+    url="https://your-server.com/webhooks",
+    event_types=["message.received"],
+)
+
+# webhook scoped to a single inbox
+client.inboxes.webhooks.create(
+    inbox_id="agent@domain.com",
+    url="https://your-server.com/webhooks",
+    event_types=["message.received"],
+)
+```
+```typescript title="TypeScript"
+// webhook scoped to a single pod
+await client.pods.webhooks.create("pod_abc123", {
+  url: "https://your-server.com/webhooks",
+  eventTypes: ["message.received"],
+});
+
+// webhook scoped to a single inbox
+await client.inboxes.webhooks.create("agent@domain.com", {
+  url: "https://your-server.com/webhooks",
+  eventTypes: ["message.received"],
+});
+```
+```bash title="CLI"
+# webhook scoped to a single pod
+agentmail pods:webhooks create \
+  --pod-id pod_abc123 \
+  --url https://your-server.com/webhooks \
+  --event-type message.received
+
+# webhook scoped to a single inbox
+agentmail inboxes:webhooks create \
+  --inbox-id agent@domain.com \
+  --url https://your-server.com/webhooks \
+  --event-type message.received
+```
+</CodeBlocks>
+
 ## The Webhook Workflow
 
 The process is straightforward:
@@ -199,6 +252,7 @@ Copy one of the blocks below into Cursor or Claude for complete Webhooks API kno
   - webhooks.get(webhook_id), webhooks.list(limit?, page_token?)
   - webhooks.update(webhook_id, add_inbox_ids?, remove_inbox_ids?, add_pod_ids?, remove_pod_ids?, event_types?)
   - webhooks.delete(webhook_id)
+  - scoped variants: pods.webhooks.* (pod_id) and inboxes.webhooks.* (inbox_id) — same CRUD, scope from the path
 
   Events: message.received, message.received.spam, message.received.blocked, message.received.unauthenticated, message.sent, message.delivered, message.bounced, message.complained, message.rejected, domain.verified
   Payload: event_type, event_id, plus message/send/delivery/bounce/complaint/reject/domain. Verify with Svix (webhook.secret).
@@ -229,6 +283,7 @@ Copy one of the blocks below into Cursor or Claude for complete Webhooks API kno
    * - webhooks.get(webhookId), webhooks.list({ limit?, pageToken? })
    * - webhooks.update(webhookId, { addInboxIds?, removeInboxIds?, addPodIds?, removePodIds?, eventTypes? })
    * - webhooks.delete(webhookId)
+   * - scoped variants: pods.webhooks.* (podId) and inboxes.webhooks.* (inboxId) — same CRUD, scope from the path
    *
    * Events: message.received, message.received.spam, message.received.blocked, message.received.unauthenticated, message.sent, message.delivered, message.bounced, message.complained, message.rejected, domain.verified
    * Note: message.received.spam, message.received.blocked, and message.received.unauthenticated are excluded by default. To receive them, explicitly include them in eventTypes and ensure the API key has label_spam_read / label_blocked_read permissions for spam and blocked events.


### PR DESCRIPTION
Syncs the Fern API definition and guides with recent agentmail-api changes. Adds the new `draft-reply`, `draft-reply-all`, and `draft-forward` endpoints (under `inboxes/messages`, returning a `Draft`) plus the `forward_of` field on `Draft` responses, and adds pod- and inbox-scoped webhook CRUD endpoints. Webhook request types are centralized in the webhooks package and composed with Fern `extends`, so each scope (inbox, pod, organization) declares only the fields it adds. Also updates the Drafts and Webhooks Overview guides and adds two changelog entries. Validated with `fern check` (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
