### PR TITLE
docs(idempotency): document Idempotency-Key header for sends

### DIFF
--- a/fern/definition/__package__.yml
+++ b/fern/definition/__package__.yml
@@ -91,3 +91,7 @@ errors:
   UnprocessableError:
     status-code: 422
     type: ErrorResponse
+
+  ConflictError:
+    status-code: 409
+    type: ErrorResponse

--- a/fern/definition/api.yml
+++ b/fern/definition/api.yml
@@ -34,3 +34,12 @@ auth-schemes:
 
 error-discrimination:
   strategy: status-code
+
+idempotency-headers:
+  Idempotency-Key:
+    type: optional<string>
+    docs: >-
+      Unique key that makes a send idempotent. A retry carrying the same key
+      returns the original message instead of sending a second email; reusing a
+      key with a different message returns a 409 conflict. Keys expire 24 hours
+      after the send completes.

--- a/fern/definition/api.yml
+++ b/fern/definition/api.yml
@@ -41,5 +41,6 @@ idempotency-headers:
     docs: >-
       Unique key that makes a send idempotent. A retry carrying the same key
       returns the original message instead of sending a second email; reusing a
-      key with a different message returns a 409 conflict. Keys expire 24 hours
-      after the send completes.
+      key with a different request — different message content, a different
+      sending inbox, or a different send endpoint — returns a 409 conflict.
+      Keys expire 24 hours after the send completes.

--- a/fern/definition/inboxes/drafts.yml
+++ b/fern/definition/inboxes/drafts.yml
@@ -116,6 +116,7 @@ service:
       method: POST
       path: /{draft_id}/send
       display-name: Send Draft
+      idempotent: true
       docs: |
         **CLI:**
         ```bash
@@ -128,4 +129,5 @@ service:
       errors:
         - global.NotFoundError
         - global.ValidationError
+        - global.ConflictError
         - messages.MessageRejectedError

--- a/fern/definition/inboxes/messages.yml
+++ b/fern/definition/inboxes/messages.yml
@@ -200,6 +200,7 @@ service:
       method: POST
       path: /send
       display-name: Send Message
+      idempotent: true
       docs: |
         **CLI:**
         ```bash
@@ -210,12 +211,14 @@ service:
       errors:
         - global.ValidationError
         - global.NotFoundError
+        - global.ConflictError
         - messages.MessageRejectedError
 
     reply:
       method: POST
       path: /{message_id}/reply
       display-name: Reply To Message
+      idempotent: true
       docs: |
         **CLI:**
         ```bash
@@ -228,12 +231,14 @@ service:
       errors:
         - global.ValidationError
         - global.NotFoundError
+        - global.ConflictError
         - messages.MessageRejectedError
 
     reply-all:
       method: POST
       path: /{message_id}/reply-all
       display-name: Reply All Message
+      idempotent: true
       docs: |
         **CLI:**
         ```bash
@@ -246,12 +251,14 @@ service:
       errors:
         - global.ValidationError
         - global.NotFoundError
+        - global.ConflictError
         - messages.MessageRejectedError
 
     forward:
       method: POST
       path: /{message_id}/forward
       display-name: Forward Message
+      idempotent: true
       docs: |
         **CLI:**
         ```bash
@@ -264,6 +271,7 @@ service:
       errors:
         - global.ValidationError
         - global.NotFoundError
+        - global.ConflictError
         - messages.MessageRejectedError
 
     draft-reply:

--- a/fern/pages/best-practices/idempotency.mdx
+++ b/fern/pages/best-practices/idempotency.mdx
@@ -2,7 +2,7 @@
 title: "Idempotent Requests"
 subtitle: "Learn how to use idempotency keys to build safe and reliable API integrations."
 slug: idempotency
-description: "A guide to using the client_id parameter in AgentMail to prevent duplicate resources and safely retry API requests."
+description: "A guide to preventing duplicate resources with client_id and preventing duplicate email sends with the Idempotency-Key header."
 ---
 
 ## What is Idempotency?
@@ -49,3 +49,43 @@ To use idempotency effectively, the `client_id` you generate must be unique and 
 - **No `@` symbol:** The `client_id` value cannot contain the `@` symbol. If you want to use an email address as an identifier, replace `@` with another character (e.g., `user_at_example.com` instead of `user@example.com`).
 
 A common and highly effective pattern is to generate a UUID (like a `UUID v4`) on your client side for a resource you are about to create, save that UUID in your own database, and then use it as the `client_id` in the API call. This gives you a reliable key to use for any retries.
+
+
+## Idempotent Sends
+
+Sends — `messages.send`, replies, forwards, and `drafts.send` — are idempotent too, but through a different mechanism. A send is **irreversible** (an email actually goes out), so instead of the body `client_id` used for resource creation, you pass an **`Idempotency-Key` HTTP header**.
+
+When a send carries an `Idempotency-Key`:
+
+- **The first time** we see the key, we send the email, record the result against the key, and return the message.
+- **A retry with the same key** returns the original `message_id` and `thread_id` and sends **no second email**.
+- **The same key with a different message** returns `409 Conflict`, so an accidental key reuse surfaces loudly instead of silently sending the wrong thing.
+- Keys are scoped to your organization and **expire 24 hours** after the send completes, after which the key can be reused.
+
+```bash title="cURL"
+curl -X POST https://api.agentmail.to/v0/inboxes/agent@yourdomain.com/messages/send \
+  -H "Authorization: Bearer $AGENTMAIL_API_KEY" \
+  -H "Idempotency-Key: order-4821-receipt" \
+  -H "Content-Type: application/json" \
+  -d '{"to": ["customer@example.com"], "subject": "Your receipt", "text": "Thanks for your order."}'
+```
+
+```python title="Python"
+message = client.inboxes.messages.send(
+    inbox_id="agent@yourdomain.com",
+    to=["customer@example.com"],
+    subject="Your receipt",
+    text="Thanks for your order.",
+    request_options={"additional_headers": {"Idempotency-Key": "order-4821-receipt"}},
+)
+```
+
+```typescript title="TypeScript"
+const message = await client.inboxes.messages.send(
+  "agent@yourdomain.com",
+  { to: ["customer@example.com"], subject: "Your receipt", text: "Thanks for your order." },
+  { headers: { "Idempotency-Key": "order-4821-receipt" } },
+);
+```
+
+Choose a key that is **unique per logical send** — either a random `UUID v4` you generate once and reuse across retries of that one send, or a deterministic key derived from your own data (e.g. `order-{{ORDER_ID}}-receipt`). The character rules match `client_id`: 1–256 characters from `A-Z a-z 0-9 - . _ ~`.

--- a/fern/pages/best-practices/idempotency.mdx
+++ b/fern/pages/best-practices/idempotency.mdx
@@ -59,7 +59,8 @@ When a send carries an `Idempotency-Key`:
 
 - **The first time** we see the key, we send the email, record the result against the key, and return the message.
 - **A retry with the same key** returns the original `message_id` and `thread_id` and sends **no second email**.
-- **The same key with a different message** returns `409 Conflict`, so an accidental key reuse surfaces loudly instead of silently sending the wrong thing.
+- **The same key with a different request** — different message content, a different sending inbox, or a different send endpoint — returns `409 Conflict`, so an accidental key reuse surfaces loudly instead of silently replaying the wrong result.
+- **An explicitly empty `Idempotency-Key` header** is rejected with a `400` rather than silently treated as absent — if you meant to use idempotency, a broken key fails loudly instead of quietly losing protection.
 - Keys are scoped to your organization and **expire 24 hours** after the send completes, after which the key can be reused.
 
 ```bash title="cURL"

--- a/fern/pages/knowledge-base/preventing-duplicate-sends.mdx
+++ b/fern/pages/knowledge-base/preventing-duplicate-sends.mdx
@@ -36,7 +36,7 @@ const sameInbox = await client.inboxes.create({
 
 The `clientId` parameter is for resource creation, not for `messages.send`. Sends are made idempotent with an **`Idempotency-Key` HTTP header** instead.
 
-Pass a unique key per logical send. A retry carrying the same key returns the original message and sends no second email; reusing a key with a different message returns `409 Conflict`. Keys expire 24 hours after the send completes.
+Pass a unique key per logical send. A retry carrying the same key returns the original message and sends no second email; reusing a key with a different request (different content, inbox, or endpoint) returns `409 Conflict`. Keys expire 24 hours after the send completes.
 
 ```typescript title="TypeScript"
 const key = `order-${orderId}-confirmation`; // unique per logical send, reused across retries

--- a/fern/pages/knowledge-base/preventing-duplicate-sends.mdx
+++ b/fern/pages/knowledge-base/preventing-duplicate-sends.mdx
@@ -34,7 +34,21 @@ const sameInbox = await client.inboxes.create({
 
 ## Preventing duplicate email sends
 
-The `clientId` parameter is for resource creation, not for `messages.send`. To prevent duplicate email sends, you need to handle this in your application logic. Here are common patterns:
+The `clientId` parameter is for resource creation, not for `messages.send`. Sends are made idempotent with an **`Idempotency-Key` HTTP header** instead.
+
+Pass a unique key per logical send. A retry carrying the same key returns the original message and sends no second email; reusing a key with a different message returns `409 Conflict`. Keys expire 24 hours after the send completes.
+
+```typescript title="TypeScript"
+const key = `order-${orderId}-confirmation`; // unique per logical send, reused across retries
+
+const message = await client.inboxes.messages.send(
+  inbox.inboxId,
+  { to: ["customer@example.com"], subject: "Order confirmation", text: "Your order has been confirmed." },
+  { headers: { "Idempotency-Key": key } },
+);
+```
+
+See the [Idempotent Requests](/idempotency) guide for the full semantics. The application-side patterns below still help when you want to dedupe on your own business state (e.g. "have I already replied to this thread?").
 
 ### Track sent messages with labels
 
@@ -84,6 +98,7 @@ Since drafts support `clientId`, creating the same draft multiple times is safe.
 
 ## Best practices
 
+- **Use an `Idempotency-Key` header on sends** (`messages.send`, replies, forwards, `drafts.send`) so retries never duplicate an email
 - **Use `clientId` on all create operations** (inboxes, pods, webhooks, drafts) to make them safe to retry
 - **Generate `clientId` from your business logic** (e.g., `order-${orderId}-confirmation`), not random UUIDs
 - **Track state with labels** to prevent your agent from processing the same message twice


### PR DESCRIPTION
Documents the send-idempotency feature shipping in agentmail-api#522, which makes sends idempotent via an `Idempotency-Key` HTTP header.

## Fern definition
- `api.yml`: add the `Idempotency-Key` idempotency-header.
- Mark the 5 send endpoints — `messages.send`, `reply`, `reply-all`, `forward`, `drafts.send` — `idempotent: true` so the generated python/node/go SDKs expose idempotency-key support.
- Add the `409 ConflictError` to those endpoints' responses (returned on same-key-different-payload and in-flight-duplicate).

## Docs
- `idempotency.mdx`: new **Idempotent Sends** section — header, replay semantics, 409 conflict, 24h window — alongside the existing `client_id` guidance for resource creation.
- `preventing-duplicate-sends.mdx`: lead with the native header; keep the label/draft patterns as secondary application-state dedupe.

`fern check` passes (0 errors). Merge after agentmail-api#522 deploys to prod so the SDKs don't advertise a parameter prod ignores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)