### PR TITLE
Fix stale MCP references to point at hosted server

### DIFF
--- a/fern/pages/integrations/agent-onboarding.mdx
+++ b/fern/pages/integrations/agent-onboarding.mdx
@@ -93,56 +93,45 @@ Add this to your MCP client configuration (Claude Code, Cursor, Codex, etc.):
 {
   "mcpServers": {
     "AgentMail": {
-      "command": "npx",
-      "args": ["-y", "agentmail-mcp"],
-      "env": {
-        "AGENTMAIL_API_KEY": "YOUR_API_KEY"
-      }
+      "url": "https://mcp.agentmail.to/mcp?apiKey=YOUR_API_KEY"
     }
   }
 }
 ```
 
-You can selectively enable specific tools using the `--tools` argument:
-
-```json
-{
-  "mcpServers": {
-    "AgentMail": {
-      "command": "npx",
-      "args": ["-y", "agentmail-mcp", "--tools", "get_message,send_message,reply_to_message"],
-      "env": {
-        "AGENTMAIL_API_KEY": "YOUR_API_KEY"
-      }
-    }
-  }
-}
-```
+Clients that support remote MCP OAuth can instead use the bare `https://mcp.agentmail.to/mcp` and authenticate in-flow.
 
 ### Available MCP Tools
 
 | Tool | Description |
 | -- | -- |
-| `create_inbox` | Create a new email inbox for an agent |
-| `list_inboxes` | List all inboxes in your account |
-| `get_inbox` | Get details of a specific inbox |
-| `delete_inbox` | Delete an inbox |
-| `send_message` | Send an email from an agent inbox |
-| `reply_to_message` | Reply to an email in a thread |
-| `forward_message` | Forward an email |
-| `update_message` | Update message labels or status |
-| `create_draft` | Create a draft email (optionally scheduled via `send_at`) |
-| `list_drafts` | List drafts in an inbox (filter by labels like `scheduled`) |
-| `get_draft` | Get a draft by ID with content and scheduled send time |
-| `update_draft` | Update a draft; use `send_at` to reschedule |
-| `send_draft` | Send a draft immediately (draft is converted to a sent message) |
-| `delete_draft` | Delete a draft; also cancels a scheduled send |
-| `list_threads` | List email threads in an inbox |
-| `get_thread` | Get a full email thread with messages |
-| `get_attachment` | Download an email attachment |
+| `list_inboxes` | List email inboxes, paginated. |
+| `get_inbox` | Get an inbox by ID. |
+| `create_inbox` | Create a new email inbox. Optionally specify username, domain, display name, and metadata. |
+| `update_inbox` | Update an inbox's display name or metadata (metadata keys merge; null removes). |
+| `delete_inbox` | Delete an inbox by ID. |
+| `list_threads` | List email threads in an inbox. Filter by labels, sender, recipient, subject, or before/after datetime, paginated. |
+| `search_threads` | Full-text search threads in an inbox, ranked by relevance (spam/trash excluded). |
+| `get_thread` | Get a thread by ID, including its messages. |
+| `get_attachment` | Get an attachment from a thread. Returns metadata and a download URL, plus extracted text for PDF/DOCX. |
+| `update_thread` | Update a thread's labels (add or remove). System labels cannot be modified. |
+| `delete_thread` | Delete a thread from an inbox. |
+| `list_messages` | List messages in an inbox. Filter by labels, sender, recipient, subject, or before/after datetime, paginated. |
+| `search_messages` | Full-text search messages in an inbox, ranked by relevance (spam/trash excluded). |
+| `send_message` | Send an email from an inbox to one or more recipients. |
+| `reply_to_message` | Reply to a message in its thread (replyAll to include all original recipients). |
+| `forward_message` | Forward a message to new recipients. |
+| `update_message` | Update a message's labels (add or remove). |
+| `create_draft` | Create a draft email. Use `sendAt` (ISO 8601) to schedule it. |
+| `list_drafts` | List drafts in an inbox. Filter by labels (e.g. `scheduled`). |
+| `get_draft` | Get a draft by ID, including content, status, and scheduled send time. |
+| `update_draft` | Update a draft. Use `sendAt` to reschedule. |
+| `send_draft` | Send a draft immediately (converted to a sent message and deleted). |
+| `delete_draft` | Delete a draft. Also cancels a scheduled send. |
+| `auth_me` | Get the identity and scope of the authenticated credential (organization, pod, inbox IDs). |
 
-<Card title="MCP Server on GitHub" icon="fa-brands fa-github" href="https://github.com/agentmail-to/agentmail-smithery-mcp">
-  View the source code, contribute, or report issues.
+<Card title="MCP Server Setup" icon="fa-brands fa-github" href="/integrations/mcp">
+  Full setup instructions for connecting the hosted AgentMail MCP server.
 </Card>
 
 ## AgentMail Docs for Agents

--- a/fern/pages/integrations/google-adk.mdx
+++ b/fern/pages/integrations/google-adk.mdx
@@ -7,7 +7,7 @@ description: AgentMail's Google Agent Development Kit (ADK) integration
 
 ## Getting started
 
-[Google Agent Development Kit (ADK)](https://google.github.io/adk-docs/) is an open-source framework for building AI agents. By connecting AgentMail to your ADK agent via the [AgentMail MCP server](https://github.com/agentmail-to/agentmail-smithery-mcp), your agent can create inboxes, send and receive emails, manage threads, and handle attachments using natural language.
+[Google Agent Development Kit (ADK)](https://google.github.io/adk-docs/) is an open-source framework for building AI agents. By connecting AgentMail to your ADK agent via the [AgentMail MCP server](/integrations/mcp), your agent can create inboxes, send and receive emails, manage threads, and handle attachments using natural language.
 
 ## Use cases
 
@@ -22,14 +22,13 @@ description: AgentMail's Google Agent Development Kit (ADK) integration
 
 ## Setup
 
-ADK supports AgentMail through the MCP tool interface. Connect the AgentMail MCP server as a local stdio transport:
+ADK supports AgentMail through the MCP tool interface. Connect to the hosted AgentMail MCP server over HTTP:
 
 <CodeBlocks>
   ```python title="Python"
   from google.adk.agents import Agent
   from google.adk.tools.mcp_tool import McpToolset
-  from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
-  from mcp import StdioServerParameters
+  from google.adk.tools.mcp_tool.mcp_session_manager import StreamableHTTPConnectionParams
 
   AGENTMAIL_API_KEY = "YOUR_AGENTMAIL_API_KEY"
 
@@ -39,18 +38,8 @@ ADK supports AgentMail through the MCP tool interface. Connect the AgentMail MCP
       instruction="Help users manage email inboxes and send messages",
       tools=[
           McpToolset(
-              connection_params=StdioConnectionParams(
-                  server_params=StdioServerParameters(
-                      command="npx",
-                      args=[
-                          "-y",
-                          "agentmail-mcp",
-                      ],
-                      env={
-                          "AGENTMAIL_API_KEY": AGENTMAIL_API_KEY,
-                      }
-                  ),
-                  timeout=30,
+              connection_params=StreamableHTTPConnectionParams(
+                  url="https://mcp.agentmail.to/mcp?apiKey=" + AGENTMAIL_API_KEY,
               ),
           )
       ],
@@ -68,13 +57,9 @@ ADK supports AgentMail through the MCP tool interface. Connect the AgentMail MCP
       instruction: "Help users manage email inboxes and send messages",
       tools: [
           new MCPToolset({
-              type: "StdioConnectionParams",
+              type: "StreamableHTTPConnectionParams",
               serverParams: {
-                  command: "npx",
-                  args: ["-y", "agentmail-mcp"],
-                  env: {
-                      AGENTMAIL_API_KEY: AGENTMAIL_API_KEY,
-                  },
+                  url: `https://mcp.agentmail.to/mcp?apiKey=${AGENTMAIL_API_KEY}`,
               },
           }),
       ],
@@ -92,35 +77,47 @@ Once connected, your ADK agent has access to the following AgentMail tools:
 
 | Tool | Description |
 | --- | --- |
-| `list_inboxes` | List all inboxes |
-| `get_inbox` | Get details for a specific inbox |
-| `create_inbox` | Create a new inbox with a username and domain |
-| `delete_inbox` | Delete an inbox |
+| `list_inboxes` | List email inboxes, paginated. |
+| `get_inbox` | Get an inbox by ID. |
+| `create_inbox` | Create a new email inbox. Optionally specify username, domain, display name, and metadata. |
+| `update_inbox` | Update an inbox's display name or metadata (metadata keys merge; null removes). |
+| `delete_inbox` | Delete an inbox by ID. |
 
 ### Thread management
 
 | Tool | Description |
 | --- | --- |
-| `list_threads` | List threads in an inbox |
-| `get_thread` | Get a specific thread with its messages |
-| `get_attachment` | Download an attachment from a message |
+| `list_threads` | List email threads in an inbox. Filter by labels, sender, recipient, subject, or before/after datetime, paginated. |
+| `search_threads` | Full-text search threads in an inbox, ranked by relevance (spam/trash excluded). |
+| `get_thread` | Get a thread by ID, including its messages. |
+| `get_attachment` | Get an attachment from a thread. Returns metadata and a download URL, plus extracted text for PDF/DOCX. |
+| `update_thread` | Update a thread's labels (add or remove). System labels cannot be modified. |
+| `delete_thread` | Delete a thread from an inbox. |
 
 ### Message operations
 
 | Tool | Description |
 | --- | --- |
-| `send_message` | Send a new email from an inbox |
-| `reply_to_message` | Reply to an existing message |
-| `forward_message` | Forward a message to another recipient |
-| `update_message` | Update message properties such as read status |
+| `list_messages` | List messages in an inbox. Filter by labels, sender, recipient, subject, or before/after datetime, paginated. |
+| `search_messages` | Full-text search messages in an inbox, ranked by relevance (spam/trash excluded). |
+| `send_message` | Send an email from an inbox to one or more recipients. |
+| `reply_to_message` | Reply to a message in its thread (replyAll to include all original recipients). |
+| `forward_message` | Forward a message to new recipients. |
+| `update_message` | Update a message's labels (add or remove). |
 
 ### Draft management
 
 | Tool | Description |
 | --- | --- |
-| `create_draft` | Create a draft email (optionally scheduled via `send_at`) |
-| `list_drafts` | List drafts in an inbox |
-| `get_draft` | Get a specific draft by ID |
-| `update_draft` | Update a draft or reschedule a scheduled send |
-| `send_draft` | Send a draft immediately |
-| `delete_draft` | Delete a draft or cancel a scheduled send |
+| `create_draft` | Create a draft email. Use `sendAt` (ISO 8601) to schedule it. |
+| `list_drafts` | List drafts in an inbox. Filter by labels (e.g. `scheduled`). |
+| `get_draft` | Get a draft by ID, including content, status, and scheduled send time. |
+| `update_draft` | Update a draft. Use `sendAt` to reschedule. |
+| `send_draft` | Send a draft immediately (converted to a sent message and deleted). |
+| `delete_draft` | Delete a draft. Also cancels a scheduled send. |
+
+### Auth
+
+| Tool | Description |
+| --- | --- |
+| `auth_me` | Get the identity and scope of the authenticated credential (organization, pod, inbox IDs). |

--- a/fern/pages/integrations/mcp.mdx
+++ b/fern/pages/integrations/mcp.mdx
@@ -67,49 +67,61 @@ Claude Code will run the same OAuth flow on first use. Connectors installed on C
 
 ## Available tools
 
-The server exposes 17 tools, grouped by resource.
+The server exposes 24 tools, grouped by resource.
 
 ### Inboxes
 
 | Tool | Description |
 | --- | --- |
-| `list_inboxes` | List inboxes in the organization. |
-| `get_inbox` | Get a single inbox by ID. |
-| `create_inbox` | Create a new inbox. |
-| `delete_inbox` | Delete an inbox. |
+| `list_inboxes` | List email inboxes, paginated. |
+| `get_inbox` | Get an inbox by ID. |
+| `create_inbox` | Create a new email inbox. Optionally specify username, domain, display name, and metadata. |
+| `update_inbox` | Update an inbox's display name or metadata (metadata keys merge; null removes). |
+| `delete_inbox` | Delete an inbox by ID. |
 
 ### Threads
 
 | Tool | Description |
 | --- | --- |
-| `list_threads` | List threads in an inbox. |
-| `get_thread` | Get a thread and its messages. |
+| `list_threads` | List email threads in an inbox. Filter by labels, sender, recipient, subject, or before/after datetime, paginated. |
+| `search_threads` | Full-text search threads in an inbox, ranked by relevance (spam/trash excluded). |
+| `get_thread` | Get a thread by ID, including its messages. |
+| `update_thread` | Update a thread's labels (add or remove). System labels cannot be modified. |
+| `delete_thread` | Delete a thread from an inbox. |
 
 ### Messages
 
 | Tool | Description |
 | --- | --- |
-| `send_message` | Send a new message from an inbox. |
-| `reply_to_message` | Reply to an existing message. |
-| `forward_message` | Forward a message to another recipient. |
-| `update_message` | Update a message, for example to change its labels. |
+| `list_messages` | List messages in an inbox. Filter by labels, sender, recipient, subject, or before/after datetime, paginated. |
+| `search_messages` | Full-text search messages in an inbox, ranked by relevance (spam/trash excluded). |
+| `send_message` | Send an email from an inbox to one or more recipients. |
+| `reply_to_message` | Reply to a message in its thread (replyAll to include all original recipients). |
+| `forward_message` | Forward a message to new recipients. |
+| `update_message` | Update a message's labels (add or remove). |
 
 ### Drafts
 
 | Tool | Description |
 | --- | --- |
-| `create_draft` | Create a draft. Set `send_at` (ISO 8601) to schedule it. |
-| `list_drafts` | List drafts in an inbox. Filter by label, for example `scheduled`. |
-| `get_draft` | Get a draft, including its content and scheduled send time. |
-| `update_draft` | Update a draft. Use `send_at` to reschedule a scheduled draft. |
-| `send_draft` | Send a draft immediately. |
+| `create_draft` | Create a draft email. Use `sendAt` (ISO 8601) to schedule it. |
+| `list_drafts` | List drafts in an inbox. Filter by labels (e.g. `scheduled`). |
+| `get_draft` | Get a draft by ID, including content, status, and scheduled send time. |
+| `update_draft` | Update a draft. Use `sendAt` to reschedule. |
+| `send_draft` | Send a draft immediately (converted to a sent message and deleted). |
 | `delete_draft` | Delete a draft. Also cancels a scheduled send. |
 
 ### Attachments
 
 | Tool | Description |
 | --- | --- |
-| `get_attachment` | Get an attachment by ID. |
+| `get_attachment` | Get an attachment from a thread. Returns metadata and a download URL, plus extracted text for PDF/DOCX. |
+
+### Auth
+
+| Tool | Description |
+| --- | --- |
+| `auth_me` | Get the identity and scope of the authenticated credential (organization, pod, inbox IDs). |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- **mcp.mdx**: corrected the tool count/table from 17 to 24, adding the 7 missing tools (`update_inbox`, `search_threads`, `update_thread`, `delete_thread`, `list_messages`, `search_messages`, `auth_me`).
- **agent-onboarding.mdx**: replaced the deprecated `npx agentmail-mcp` stdio config with the hosted HTTP config (`https://mcp.agentmail.to/mcp?apiKey=...`); dropped the `--tools` selective-tool example entirely since the hosted server has no equivalent flag; regenerated the 17->24 tool table; repointed the "MCP Server on GitHub" card from the `agentmail-smithery-mcp` scaffold repo to the hosted setup docs (`/integrations/mcp`).
- **google-adk.mdx**: repointed the intro link from `agentmail-smithery-mcp` to the hosted MCP docs; rewrote the Python and TypeScript ADK samples to use `StreamableHTTPConnectionParams`/`StreamableHTTPConnectionParams` against `https://mcp.agentmail.to/mcp` instead of `StdioConnectionParams` + `npx agentmail-mcp`; regenerated the 17->24 tool table.

Why: these pages pointed agents/users at the deprecated local `npx agentmail-mcp` package and the unrelated `agentmail-smithery-mcp` scaffold repo instead of the current hosted MCP server, and their tool tables were stale (17 vs. the current 24 tools).

Left untouched: the `agentmail-manufact-mcp` GitHub link in `mcp.mdx` (that is the hosted server's actual source repo, already correct) and the `smithery.mdx` stub / `docs.yml` redirect entries (not user-facing, out of scope).

## Test plan

- [ ] Spot-check rendered `mcp.mdx`, `agent-onboarding.mdx`, and `google-adk.mdx` pages for correct MDX/table rendering
- [ ] Confirm no remaining `npx ... agentmail-mcp` or bare `https://mcp.agentmail.to` (no `/mcp`) references in the three files
- [ ] Confirm hosted config JSON/code samples are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)