### PR TITLE
docs: correct thread/message delete semantics and document trash flow

### DIFF
--- a/fern/definition/inboxes/threads.yml
+++ b/fern/definition/inboxes/threads.yml
@@ -126,7 +126,7 @@ service:
       path: /{thread_id}
       display-name: Delete Thread
       docs: |
-        Moves the thread to trash by adding a trash label to all messages. If the thread is already in trash, it will be permanently deleted. Use `permanent=true` to force permanent deletion.
+        Permanently deletes a thread and all of its messages.
 
         **CLI:**
         ```bash
@@ -134,11 +134,5 @@ service:
         ```
       path-parameters:
         thread_id: threads.ThreadId
-      request:
-        name: DeleteThreadRequest
-        query-parameters:
-          permanent:
-            type: optional<boolean>
-            docs: If true, permanently delete the thread instead of moving to trash.
       errors:
         - global.NotFoundError

--- a/fern/definition/pods/threads.yml
+++ b/fern/definition/pods/threads.yml
@@ -126,7 +126,7 @@ service:
       path: /{thread_id}
       display-name: Delete Thread
       docs: |
-        Moves the thread to trash by adding a trash label to all messages. If the thread is already in trash, it will be permanently deleted. Use `permanent=true` to force permanent deletion.
+        Permanently deletes a thread and all of its messages.
 
         **CLI:**
         ```bash
@@ -134,11 +134,5 @@ service:
         ```
       path-parameters:
         thread_id: threads.ThreadId
-      request:
-        name: DeleteThreadRequest
-        query-parameters:
-          permanent:
-            type: optional<boolean>
-            docs: If true, permanently delete the thread instead of moving to trash.
       errors:
         - global.NotFoundError

--- a/fern/definition/threads.yml
+++ b/fern/definition/threads.yml
@@ -286,7 +286,7 @@ service:
       path: /{thread_id}
       display-name: Delete Thread
       docs: |
-        Moves the thread to trash by adding a trash label to all messages. If the thread is already in trash, it will be permanently deleted. Use `permanent=true` to force permanent deletion.
+        Permanently deletes a thread and all of its messages.
 
         **CLI:**
         ```bash
@@ -294,11 +294,5 @@ service:
         ```
       path-parameters:
         thread_id: ThreadId
-      request:
-        name: DeleteThreadRequest
-        query-parameters:
-          permanent:
-            type: optional<boolean>
-            docs: If true, permanently delete the thread instead of moving to trash.
       errors:
         - global.NotFoundError

--- a/fern/pages/core-concepts/labels.mdx
+++ b/fern/pages/core-concepts/labels.mdx
@@ -131,6 +131,17 @@ agentmail inboxes:messages update \
 
 </CodeBlocks>
 
+<Callout title="Moving to trash" intent="info">
+  To move a `Message` or `Thread` to trash, add the `trash` `Label` to it with
+  the update (PATCH) method — the same way you add any other `Label`. Reads and
+  searches exclude trashed items by default. To remove it from trash, remove the
+  `trash` `Label`.
+
+  Note this is distinct from the [Delete Thread](/api-reference/threads/delete)
+  and [Delete Message](/api-reference/messages/delete) endpoints, which
+  permanently delete the resource and all of its data.
+</Callout>
+
 ### 3. Filtering by `Labels`
 
 This is where `Labels` become truly powerful. You can list `Threads`, `Messages`, and `Drafts` by filtering for one or more `Labels`, allowing you to create highly targeted queries.

--- a/fern/pages/integrations/sim.mdx
+++ b/fern/pages/integrations/sim.mdx
@@ -56,7 +56,7 @@ Once connected, Sim provides access to the following AgentMail operations:
 | Operation | Description |
 | --- | --- |
 | Get thread | Retrieve a thread and its messages |
-| Delete thread | Delete a thread (moves to trash, or permanently deletes if already in trash) |
+| Delete thread | Permanently delete a thread and all of its messages |
 
 ### Draft management
 


### PR DESCRIPTION
Removes the undocumented `permanent` query param from the Delete Thread endpoint (inboxes, pods, and top-level definitions) — the API only reads the `thread_id` path param and permanently deletes the thread and all of its messages, so the flag was never implemented. Updates the delete descriptions and the Sim integration table to reflect that behavior. Adds a "Moving to trash" callout to the Labels concept page explaining that trashing a `Message` or `Thread` is done by adding the `trash` label via the update (PATCH) endpoint, which is distinct from permanent deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)