### PR TITLE
Remove credential-bearing MCP URLs from integration docs

### DIFF
--- a/fern/pages/integrations/agent-onboarding.mdx
+++ b/fern/pages/integrations/agent-onboarding.mdx
@@ -87,19 +87,32 @@ MCP (Model Context Protocol) is an open protocol that standardizes how applicati
 
 ### Setup
 
-Add this to your MCP client configuration (Claude Code, Cursor, Codex, etc.):
+Add this to your MCP client configuration (Claude Code, Cursor, Codex, etc.). Clients that support remote MCP OAuth should use the bare URL and authenticate in-flow:
 
 ```json
 {
   "mcpServers": {
     "AgentMail": {
-      "url": "https://mcp.agentmail.to/mcp?apiKey=YOUR_API_KEY"
+      "url": "https://mcp.agentmail.to/mcp"
     }
   }
 }
 ```
 
-Clients that support remote MCP OAuth can instead use the bare `https://mcp.agentmail.to/mcp` and authenticate in-flow.
+For clients that don't implement OAuth but support custom headers, pass the key as an `x-api-key` header instead:
+
+```json
+{
+  "mcpServers": {
+    "AgentMail": {
+      "url": "https://mcp.agentmail.to/mcp",
+      "headers": {
+        "x-api-key": "${AGENTMAIL_API_KEY}"
+      }
+    }
+  }
+}
+```
 
 ### Available MCP tools
 

--- a/fern/pages/integrations/google-adk.mdx
+++ b/fern/pages/integrations/google-adk.mdx
@@ -26,11 +26,13 @@ ADK supports AgentMail through the MCP tool interface. Connect to the hosted Age
 
 <CodeBlocks>
   ```python title="Python"
+  import os
+
   from google.adk.agents import Agent
   from google.adk.tools.mcp_tool import McpToolset
   from google.adk.tools.mcp_tool.mcp_session_manager import StreamableHTTPConnectionParams
 
-  AGENTMAIL_API_KEY = "YOUR_AGENTMAIL_API_KEY"
+  AGENTMAIL_API_KEY = os.environ["AGENTMAIL_API_KEY"]
 
   root_agent = Agent(
       model="gemini-2.5-pro",
@@ -39,7 +41,8 @@ ADK supports AgentMail through the MCP tool interface. Connect to the hosted Age
       tools=[
           McpToolset(
               connection_params=StreamableHTTPConnectionParams(
-                  url="https://mcp.agentmail.to/mcp?apiKey=" + AGENTMAIL_API_KEY,
+                  url="https://mcp.agentmail.to/mcp",
+                  headers={"x-api-key": AGENTMAIL_API_KEY},
               ),
           )
       ],
@@ -49,7 +52,7 @@ ADK supports AgentMail through the MCP tool interface. Connect to the hosted Age
   ```typescript title="TypeScript"
   import { LlmAgent, MCPToolset } from "@google/adk";
 
-  const AGENTMAIL_API_KEY = "YOUR_AGENTMAIL_API_KEY";
+  const AGENTMAIL_API_KEY = process.env.AGENTMAIL_API_KEY;
 
   const rootAgent = new LlmAgent({
       model: "gemini-2.5-pro",
@@ -59,7 +62,8 @@ ADK supports AgentMail through the MCP tool interface. Connect to the hosted Age
           new MCPToolset({
               type: "StreamableHTTPConnectionParams",
               serverParams: {
-                  url: `https://mcp.agentmail.to/mcp?apiKey=${AGENTMAIL_API_KEY}`,
+                  url: "https://mcp.agentmail.to/mcp",
+                  headers: { "x-api-key": AGENTMAIL_API_KEY },
               },
           }),
       ],

--- a/fern/pages/integrations/mcp.mdx
+++ b/fern/pages/integrations/mcp.mdx
@@ -12,7 +12,7 @@ The Model Context Protocol (MCP) is an open standard that lets AI clients call e
 The server supports two authentication paths:
 
 - **OAuth** (default, recommended for Claude Desktop and Claude.ai). The client signs in through `console.agentmail.to` and the server uses your console identity for every call.
-- **API key** (for Cursor, Windsurf, and other clients that do not implement the MCP OAuth flow). Pass the key as a `?apiKey=` query parameter or an `x-api-key` header.
+- **API key** (for Cursor, Windsurf, and other clients that do not implement the MCP OAuth flow). Pass the key as an `x-api-key` header; query-string keys end up in logs and history.
 
 If you belong to more than one AgentMail organization, the OAuth consent screen will ask you to pick which one to use before completing the connection.
 
@@ -40,20 +40,17 @@ OAuth is the recommended path for Claude products. You do not need an API key; t
 ```json
 {
   "agentmail": {
-    "url": "https://mcp.agentmail.to/mcp?apiKey=YOUR_API_KEY"
+    "url": "https://mcp.agentmail.to/mcp",
+    "headers": {
+      "x-api-key": "${AGENTMAIL_API_KEY}"
+    }
   }
 }
 ```
 
-If your client supports custom headers, you can pass the key as a header instead of a query parameter:
-
-```
-x-api-key: YOUR_API_KEY
-```
-
 ### Windsurf and other MCP clients
 
-Use the same URL and API key pattern as Cursor. Most clients accept either the `?apiKey=YOUR_API_KEY` query form or the `x-api-key` header.
+Use the same URL and header pattern as Cursor. If a client cannot send custom headers, use the [stdio-based compatibility bridge](https://github.com/agentmail-to/agentmail-mcp) instead and pass `AGENTMAIL_API_KEY` through the subprocess environment.
 
 ### Claude Code
 


### PR DESCRIPTION
> **DO NOT MERGE — @sanjith merges manually.** Coordinate with the agentmail-skills consolidation PR so skills and docs teach the same setup.

Replaces every `?apiKey=` MCP configuration in `mcp.mdx`, `agent-onboarding.mdx`, and `google-adk.mdx`: OAuth as the primary path, `x-api-key` header (key from env/host secret store) as the API-key fallback, stdio bridge for clients supporting neither. Keys in URLs end up in server logs, proxies, and shell history (OWASP REST + MCP authorization spec both prohibit it). google-adk snippets verified against the real ADK `StreamableHTTPConnectionParams`/`serverParams` header APIs.

Flagged for a later wave (not touched here): hard-coded model IDs in `google-adk.mdx` and `langchain.mdx`; `fern/pages/webhooks.mdx` not in this sparse checkout — verify it teaches Svix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)