### PR TITLE
fix(node-sdk): declare @x402/fetch as an optional peer dependency

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -40,6 +40,15 @@ groups:
           noSerdeLayer: false
           skipResponseValidation: true
           shouldGenerateWebsocketClients: true
+          # The hand-written wrapper (src/wrapper/x402.ts, src/wrapper/Client.ts)
+          # lazily imports @x402/fetch for the opt-in payments feature. Declare it
+          # as an optional peer dependency so bundlers, file tracers, and isolated
+          # installers can resolve the import (agentmail-node#24).
+          extraPeerDependencies:
+            "@x402/fetch": "^2"
+          extraPeerDependenciesMeta:
+            "@x402/fetch":
+              optional: true
           packageJson:
             description:
               "The email inbox API for AI agents. Send, receive, reply, and


### PR DESCRIPTION
Fixes agentmail-to/agentmail-node#24.

## Problem

The node SDK's wrapper lazily imports `@x402/fetch` (`src/wrapper/x402.ts`, `src/wrapper/Client.ts`) for the opt-in payments feature, but the package is not declared anywhere in `package.json`. As the issue lays out, that phantom dependency breaks bundlers (unresolvable-import errors), file tracers such as `@vercel/nft` (a configured external must be resolvable on disk), and isolated installers (pnpm, bun), forcing consumers to carry externalization workarounds. The wrapper's own `src/wrapper/x402-types.d.ts` module shim exists precisely because TypeScript cannot resolve the undeclared package.

## Why the fix is here and not in agentmail-node

`package.json` in agentmail-node is Fern-generated and not listed in `.fernignore`, so declaring the dependency there directly would be overwritten on the next regeneration. The generator config in this repo is the durable layer: the `packageJson` block's fields (description, keywords, license) already flow into the published package, and the TypeScript generator supports `extraPeerDependencies` / `extraPeerDependenciesMeta` for exactly this case.

## Change

```yaml
extraPeerDependencies:
  "@x402/fetch": "^2"
extraPeerDependenciesMeta:
  "@x402/fetch":
    optional: true
```

This keeps payments opt-in (consumers install `@x402/fetch` only if they use the feature) while making the import visible to every toolchain. All published `@x402/fetch` versions are 2.x, and the wrapper uses only `x402HTTPClient` and `wrapFetchWithPayment`, both stable across 2.x.

## Verification

`npx fern-api check`: 0 errors, 9 warnings — identical to unmodified `main` (the warnings are pre-existing).

## Follow-up (out of scope here)

Once this is released, `src/wrapper/x402-types.d.ts` in agentmail-node could be dropped in favor of the real types from the now-resolvable package.