### PR TITLE
docs: reconcile API key permissions with what the API enforces

### DIFF
--- a/fern/definition/api-keys.yml
+++ b/fern/definition/api-keys.yml
@@ -177,27 +177,27 @@ types:
       inbox_delete:
         type: optional<boolean>
         docs: Delete inboxes.
-      thread_read:
-        type: optional<boolean>
-        docs: Read threads.
-      thread_delete:
-        type: optional<boolean>
-        docs: Delete threads.
       message_read:
         type: optional<boolean>
-        docs: Read messages.
+        docs: Read messages. Also required to read threads.
       message_send:
         type: optional<boolean>
         docs: Send messages.
       message_update:
         type: optional<boolean>
-        docs: Update message labels.
+        docs: Update message labels. Also required to update threads.
+      message_delete:
+        type: optional<boolean>
+        docs: Delete messages. Also required to delete threads.
       label_spam_read:
         type: optional<boolean>
         docs: Access messages labeled spam.
       label_blocked_read:
         type: optional<boolean>
         docs: Access messages labeled blocked.
+      label_unauthenticated_read:
+        type: optional<boolean>
+        docs: Access messages labeled unauthenticated.
       label_trash_read:
         type: optional<boolean>
         docs: Access messages labeled trash.

--- a/fern/pages/core-concepts/permissions.mdx
+++ b/fern/pages/core-concepts/permissions.mdx
@@ -43,13 +43,6 @@ A restricted API key cannot create a child key with more permissions than itself
 | `inbox_update` | Update inbox settings |
 | `inbox_delete` | Delete inboxes |
 
-### Threads
-
-| Permission | Description |
-| --- | --- |
-| `thread_read` | Read threads |
-| `thread_delete` | Delete threads |
-
 ### Messages
 
 | Permission | Description |
@@ -57,6 +50,21 @@ A restricted API key cannot create a child key with more permissions than itself
 | `message_read` | Read messages |
 | `message_send` | Send messages |
 | `message_update` | Update message labels |
+| `message_delete` | Delete messages |
+
+### Threads
+
+Threads are groupings of messages and have no permissions of their own. Every thread operation is governed by the equivalent message permission:
+
+| Operation | Required permission |
+| --- | --- |
+| List, get, or search threads | `message_read` |
+| Update thread labels | `message_update` |
+| Delete a thread | `message_delete` |
+
+<Warning>
+  There is no `thread_read` or `thread_delete` permission. Granting `message_delete` on a key also lets that key delete whole threads. To create a key that can read and label messages but cannot delete anything, leave `message_delete` unset or `false`.
+</Warning>
 
 ### Label Visibility
 
@@ -64,6 +72,7 @@ A restricted API key cannot create a child key with more permissions than itself
 | --- | --- |
 | `label_spam_read` | Access messages labeled as spam |
 | `label_blocked_read` | Access messages labeled as blocked |
+| `label_unauthenticated_read` | Access messages labeled as unauthenticated |
 | `label_trash_read` | Access messages labeled as trash |
 
 <Info>
@@ -71,7 +80,7 @@ A restricted API key cannot create a child key with more permissions than itself
 </Info>
 
 <Callout intent="info" title="Event subscriptions">
-  Label visibility permissions also control whether an API key can subscribe to the corresponding event types on [webhooks](/events) and [WebSockets](/websockets). An API key without `label_spam_read` cannot create a webhook or WebSocket subscription for `message.received.spam` events, and an API key without `label_blocked_read` cannot subscribe to `message.received.blocked` events.
+  Label visibility permissions also control whether an API key can subscribe to the corresponding event types on [webhooks](/events) and [WebSockets](/websockets). An API key without `label_spam_read` cannot create a webhook or WebSocket subscription for `message.received.spam` events, and the same applies to `label_blocked_read` for `message.received.blocked` and `label_unauthenticated_read` for `message.received.unauthenticated`. `label_trash_read` has no corresponding event type, so it gates reads only.
 </Callout>
 
 ### Drafts
@@ -122,6 +131,7 @@ A restricted API key cannot create a child key with more permissions than itself
 | --- | --- |
 | `api_key_read` | Read API keys |
 | `api_key_create` | Create API keys |
+| `api_key_update` | Update API keys |
 | `api_key_delete` | Delete API keys |
 
 ### Pods
@@ -148,7 +158,6 @@ key = client.api_keys.create(
     name="read-only-agent",
     permissions={
         "inbox_read": True,
-        "thread_read": True,
         "message_read": True,
         "draft_read": True,
         "webhook_read": True,
@@ -159,6 +168,7 @@ key = client.api_keys.create(
         "pod_read": True,
         "label_spam_read": True,
         "label_blocked_read": True,
+        "label_unauthenticated_read": True,
         "label_trash_read": True,
     }
 )
@@ -175,7 +185,6 @@ const key = await client.apiKeys.create({
   name: "read-only-agent",
   permissions: {
     inboxRead: true,
-    threadRead: true,
     messageRead: true,
     draftRead: true,
     webhookRead: true,
@@ -186,6 +195,7 @@ const key = await client.apiKeys.create({
     podRead: true,
     labelSpamRead: true,
     labelBlockedRead: true,
+    labelUnauthenticatedRead: true,
     labelTrashRead: true,
   },
 });
@@ -199,7 +209,6 @@ agentmail api-keys create \
   --name "read-only-agent" \
   --permissions '{
     "inbox_read": true,
-    "thread_read": true,
     "message_read": true,
     "draft_read": true,
     "webhook_read": true,
@@ -210,6 +219,7 @@ agentmail api-keys create \
     "pod_read": true,
     "label_spam_read": true,
     "label_blocked_read": true,
+    "label_unauthenticated_read": true,
     "label_trash_read": true
   }'
 ```
@@ -217,7 +227,7 @@ agentmail api-keys create \
 
 ### No-spam key
 
-Create a key with full access but block visibility into spam, blocked, and trash content. This is useful for agent-facing keys where you want to prevent the agent from processing unwanted email.
+Create a key with full access but block visibility into spam, blocked, unauthenticated, and trash content. This is useful for agent-facing keys where you want to prevent the agent from processing unwanted email.
 
 <CodeBlocks>
 ```python title="Python"
@@ -228,13 +238,13 @@ key = client.api_keys.create(
         "inbox_create": True,
         "inbox_update": True,
         "inbox_delete": True,
-        "thread_read": True,
-        "thread_delete": True,
         "message_read": True,
         "message_send": True,
         "message_update": True,
+        "message_delete": True,
         "label_spam_read": False,
         "label_blocked_read": False,
+        "label_unauthenticated_read": False,
         "label_trash_read": False,
         "draft_read": True,
         "draft_create": True,
@@ -255,6 +265,7 @@ key = client.api_keys.create(
         "metrics_read": True,
         "api_key_read": True,
         "api_key_create": True,
+        "api_key_update": True,
         "api_key_delete": True,
         "pod_read": True,
         "pod_create": True,
@@ -271,13 +282,13 @@ const key = await client.apiKeys.create({
     inboxCreate: true,
     inboxUpdate: true,
     inboxDelete: true,
-    threadRead: true,
-    threadDelete: true,
     messageRead: true,
     messageSend: true,
     messageUpdate: true,
+    messageDelete: true,
     labelSpamRead: false,
     labelBlockedRead: false,
+    labelUnauthenticatedRead: false,
     labelTrashRead: false,
     draftRead: true,
     draftCreate: true,
@@ -298,6 +309,7 @@ const key = await client.apiKeys.create({
     metricsRead: true,
     apiKeyRead: true,
     apiKeyCreate: true,
+    apiKeyUpdate: true,
     apiKeyDelete: true,
     podRead: true,
     podCreate: true,
@@ -315,13 +327,13 @@ agentmail api-keys create \
     "inbox_create": true,
     "inbox_update": true,
     "inbox_delete": true,
-    "thread_read": true,
-    "thread_delete": true,
     "message_read": true,
     "message_send": true,
     "message_update": true,
+    "message_delete": true,
     "label_spam_read": false,
     "label_blocked_read": false,
+    "label_unauthenticated_read": false,
     "label_trash_read": false,
     "draft_read": true,
     "draft_create": true,
@@ -342,6 +354,7 @@ agentmail api-keys create \
     "metrics_read": true,
     "api_key_read": true,
     "api_key_create": true,
+    "api_key_update": true,
     "api_key_delete": true,
     "pod_read": true,
     "pod_create": true,
@@ -365,16 +378,18 @@ Copy one of the blocks below into Cursor or Claude for complete Permissions API 
 
   Permission fields (all optional<bool>, resource_action format):
     Inboxes: inbox_read, inbox_create, inbox_update, inbox_delete
-    Threads: thread_read, thread_delete
-    Messages: message_read, message_send, message_update
-    Label visibility: label_spam_read, label_blocked_read, label_trash_read
+    Messages: message_read, message_send, message_update, message_delete
+    Label visibility: label_spam_read, label_blocked_read, label_unauthenticated_read, label_trash_read
     Drafts: draft_read, draft_create, draft_update, draft_delete, draft_send
     Webhooks: webhook_read, webhook_create, webhook_update, webhook_delete
     Domains: domain_read, domain_create, domain_update, domain_delete
     Lists: list_entry_read, list_entry_create, list_entry_delete
     Metrics: metrics_read
-    API Keys: api_key_read, api_key_create, api_key_delete
+    API Keys: api_key_read, api_key_create, api_key_update, api_key_delete
     Pods: pod_read, pod_create, pod_delete
+
+  Threads have no permissions of their own: thread reads use message_read,
+  thread label updates use message_update, and thread deletes use message_delete.
 
   API: api_keys.create(name, permissions={...})
   """
@@ -385,7 +400,7 @@ Copy one of the blocks below into Cursor or Claude for complete Permissions API 
   # read-only key
   key = client.api_keys.create(
       name="read-only",
-      permissions={"inbox_read": True, "message_read": True, "thread_read": True}
+      permissions={"inbox_read": True, "message_read": True}
   )
   print(key.api_key)
   ```
@@ -400,16 +415,18 @@ Copy one of the blocks below into Cursor or Claude for complete Permissions API 
    *
    * Permission fields (all optional boolean, resourceAction format):
    *   Inboxes: inboxRead, inboxCreate, inboxUpdate, inboxDelete
-   *   Threads: threadRead, threadDelete
-   *   Messages: messageRead, messageSend, messageUpdate
-   *   Label visibility: labelSpamRead, labelBlockedRead, labelTrashRead
+   *   Messages: messageRead, messageSend, messageUpdate, messageDelete
+   *   Label visibility: labelSpamRead, labelBlockedRead, labelUnauthenticatedRead, labelTrashRead
    *   Drafts: draftRead, draftCreate, draftUpdate, draftDelete, draftSend
    *   Webhooks: webhookRead, webhookCreate, webhookUpdate, webhookDelete
    *   Domains: domainRead, domainCreate, domainUpdate, domainDelete
    *   Lists: listEntryRead, listEntryCreate, listEntryDelete
    *   Metrics: metricsRead
-   *   API Keys: apiKeyRead, apiKeyCreate, apiKeyDelete
+   *   API Keys: apiKeyRead, apiKeyCreate, apiKeyUpdate, apiKeyDelete
    *   Pods: podRead, podCreate, podDelete
+   *
+   * Threads have no permissions of their own: thread reads use messageRead,
+   * thread label updates use messageUpdate, and thread deletes use messageDelete.
    *
    * API: apiKeys.create({ name, permissions: {...} })
    */
@@ -421,7 +438,7 @@ Copy one of the blocks below into Cursor or Claude for complete Permissions API 
     // read-only key
     const key = await client.apiKeys.create({
       name: "read-only",
-      permissions: { inboxRead: true, messageRead: true, threadRead: true },
+      permissions: { inboxRead: true, messageRead: true },
     });
     console.log(key.apiKey);
   }
@@ -433,4 +450,4 @@ Copy one of the blocks below into Cursor or Claude for complete Permissions API 
 
 - **Use the principle of least privilege.** Only grant the permissions your agent actually needs. A support agent that reads and replies to emails does not need `domain_create` or `inbox_delete`.
 - **Combine with scopes for defense in depth.** Pair permissions with [pod-scoped](/multi-tenancy#pod-scoped-keys) or [inbox-scoped](/multi-tenancy#inbox-scoped-keys) keys. Scopes limit *which* resources a key can see, while permissions limit *what* it can do.
-- **Filter unwanted content from agents.** Set `label_spam_read`, `label_blocked_read`, and `label_trash_read` to `false` on agent-facing keys. This prevents agents from seeing or processing unwanted email, keeping their context clean.
+- **Filter unwanted content from agents.** Set `label_spam_read`, `label_blocked_read`, `label_unauthenticated_read`, and `label_trash_read` to `false` on agent-facing keys. This prevents agents from seeing or processing unwanted email, keeping their context clean.

--- a/fern/pages/websockets.mdx
+++ b/fern/pages/websockets.mdx
@@ -278,7 +278,7 @@ socket.sendSubscribe({
 ```
 
 <Callout intent="info">
-  By default (when no `event_types` are specified), spam, blocked, and unauthenticated events are excluded from the subscription. To receive them, explicitly include `message.received.spam`, `message.received.blocked`, or `message.received.unauthenticated` in `event_types`. Spam and blocked events also require the `label_spam_read` or `label_blocked_read` permission.
+  By default (when no `event_types` are specified), spam, blocked, and unauthenticated events are excluded from the subscription. To receive them, explicitly include `message.received.spam`, `message.received.blocked`, or `message.received.unauthenticated` in `event_types`. These events also require the matching label visibility permission: `label_spam_read`, `label_blocked_read`, or `label_unauthenticated_read`.
 </Callout>
 
 ---
@@ -411,7 +411,7 @@ Copy one of the blocks below into Cursor or Claude for WebSockets in one shot.
   Async: async with client.websockets.connect() as socket: await socket.send_subscribe(...); async for event in socket: ...
   Subscribe(inbox_ids=[...], pod_ids=[...], event_types=[...])
   Event types: Subscribed, MessageReceivedEvent, MessageSentEvent, MessageDeliveredEvent, MessageBouncedEvent, MessageComplainedEvent, MessageRejectedEvent, DomainVerifiedEvent
-  Spam, blocked, and unauthenticated events require explicit opt-in via event_types. Spam and blocked events require label_spam_read / label_blocked_read permissions.
+  Spam, blocked, and unauthenticated events require explicit opt-in via event_types, plus the matching label_spam_read / label_blocked_read / label_unauthenticated_read permission.
   """
   from agentmail import AgentMail, Subscribe, Subscribed, MessageReceivedEvent
 


### PR DESCRIPTION
## Why

Customer report (Tanasi Studio, 2026-07-15): they created an inbox-scoped key with `thread_read: false` and `thread_delete: false` set explicitly, and both came back `true`. They also found that a control key granted `thread_delete: true` could not delete a thread at all.

Both observations are explained by the same thing: **`thread_read` and `thread_delete` do not exist on the server.** They were removed at the end of March 2026 (`9542d122`, `0f4790b3`) when thread authorization was consolidated onto the message permissions. This repo's definition was never updated, so we have been publishing two permissions the API does not implement for four months.

The API strips unrecognized fields inside the `permissions` object rather than rejecting them, so a key requesting `thread_delete` silently receives nothing and still gets a 200. That is what made the drift invisible to callers.

The customer's key was never actually at risk — thread deletion requires `message_delete`, which they had not granted. But `message_delete` was also undocumented, so the question was unanswerable from our reference.

## What changed

**`fern/definition/api-keys.yml`**
- Remove `thread_read` and `thread_delete`.
- Add `message_delete` and `label_unauthenticated_read`, both enforced by the server but never published.

**`fern/pages/core-concepts/permissions.mdx`**
- Replace the Threads permission table with an operation-to-permission mapping, plus a warning that no thread permission exists.
- Add the missing permissions to the reference tables, including `api_key_update`.
- Update all code examples and both Cursor/Claude blocks so no example teaches a permission that does nothing.

**`fern/pages/websockets.mdx`**
- `message.received.unauthenticated` is gated by `label_unauthenticated_read` the same way spam and blocked are; the page claimed only spam and blocked required a permission.

## Verification

The definition and `agentmail-api/src/core/schemas/api-key.ts` now agree on all 36 keys in the same order, every server permission appears in a reference table, and no phantom permission remains in any example. Checked programmatically against the current `permissionShape`.

## ⚠️ Breaking for generated SDKs

Removing the two fields drops them from the `ApiKeyPermissions` model. They never had any effect, so no behavior changes, but setting them explicitly becomes a type error on upgrade. The reporting customer sets both today. This needs a changelog entry with a breaking-changes section.

## Not covered here

- **Nothing binds these two lists.** They are hand-maintained in separate repos with no CI check, which is the actual root cause. Tracked separately.
- **Silent stripping.** Worth deciding whether the nested `permissions` object should reject unknown keys. Flipping it straight to strict would 400 anyone who copy-pasted the old example on this page, which contained `thread_read`, so it needs a deprecation path.
- **Customer impact.** Anyone who granted `thread_read: true` without `message_read: true` has had a thread-blind key since March. Findable by scanning `api-key-table` for keys created after 2026-03-30 with a `permissions` attribute and no `message_read`.

## Testing

Not preview-built locally — the `fern` CLI is not installed on this machine. **The new Threads section adds a `<Warning>` component; please confirm it renders before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)