### PR TITLE
docs: publish AgentID owner permission contract

### DIFF
--- a/fern/changelog/2026-07-20-agentid-public-key-auth.mdx
+++ b/fern/changelog/2026-07-20-agentid-public-key-auth.mdx
@@ -15,7 +15,7 @@ and TypeScript approval helpers.
 
 - `POST /v0/api-keys/public-keys` - Register only a public P-256 JWK and receive the server-owned `api_key_id` used as `kid`
 - `GET /v0/api-keys/public-keys` - List public-key credentials without mixing in bearer credentials
-- `PATCH /v0/api-keys/public-keys/{api_key_id}` - Rename a credential without mutating security-relevant fields
+- `PATCH /v0/api-keys/public-keys/{api_key_id}` - Update a credential's name or AgentID owner-claim permissions
 - `DELETE /v0/api-keys/public-keys/{api_key_id}` - Revoke one public-key credential
 - `POST /v0/api-keys/public-keys/agentid-sign-in/revoke-all` - Idempotently invalidate every current AgentID sign-in key in an organization
 
@@ -26,6 +26,7 @@ and TypeScript approval helpers.
 **New features:**
 
 - **Scoped credentials**: Register organization-, pod-, or inbox-scoped keys with inherited scope and expiry defaults.
+- **Owner-claim controls**: Independently allow or block the `owner_profile` and `owner_email` OAuth scopes on each public-key credential.
 - **Generated SDK contract**: Generate P-256 keys, register only public coordinates, pin the approval header and claims, and keep private keys below model context once corresponding SDK releases are published.
 
 ### Use cases

--- a/fern/definition/api-keys.yml
+++ b/fern/definition/api-keys.yml
@@ -80,6 +80,32 @@ types:
           pattern: "^[A-Za-z0-9_-]{43}$"
         docs: RFC 7638 SHA-256 JWK thumbprint encoded as unpadded base64url.
 
+  PublicKeyPermissionSelection:
+    docs: |
+      AgentID owner-claim permissions selected for a public-key credential.
+      These permissions authorize OAuth claim disclosure at AgentID sign-in;
+      they do not authorize AgentMail REST API operations. Omitted or false
+      fields are disabled when this object is supplied.
+    properties:
+      owner_profile:
+        type: optional<boolean>
+        docs: Allow the credential to authorize the `owner_profile` OAuth scope and its `owner_name` claim.
+      owner_email:
+        type: optional<boolean>
+        docs: Allow the credential to authorize the `owner_email` OAuth scope and its `owner_email` claim.
+
+  PublicKeyPermissions:
+    docs: |
+      Effective AgentID owner-claim permissions. Both controls are always
+      returned explicitly so callers do not need to infer false from omission.
+    properties:
+      owner_profile:
+        type: boolean
+        docs: Whether the credential may authorize the `owner_profile` OAuth scope.
+      owner_email:
+        type: boolean
+        docs: Whether the credential may authorize the `owner_email` OAuth scope.
+
   PublicKeyCredential:
     docs: |
       An AgentID sign-in credential. `type` and `api_key_id` are server-owned;
@@ -97,6 +123,7 @@ types:
         docs: Human-readable credential name.
       public_key: PublicKeyMaterial
       scope: PublicKeyScope
+      permissions: PublicKeyPermissions
       expires_at:
         type: optional<datetime>
         docs: Immutable absolute expiry. Omitted when the credential does not expire.
@@ -109,8 +136,8 @@ types:
   CreatePublicKeyRequest:
     docs: |
       Register only a public P-256 JWK. Credential type, `api_key_id`, sign-in
-      eligibility, permissions, and generation are server-owned and are not
-      request properties.
+      eligibility, and generation are server-owned and are not request
+      properties.
     properties:
       public_key: PublicJwk
       name:
@@ -129,17 +156,31 @@ types:
         docs: |
           Future absolute expiry. Omit to inherit the registering bearer key's
           expiry. A child credential cannot outlive its creator.
+      permissions:
+        type: optional<PublicKeyPermissionSelection>
+        docs: |
+          Omit to inherit the registering bearer key's effective
+          `owner_profile` and `owner_email` permissions. Supplying an object
+          selects an exact subset: omitted or false fields are disabled, and a
+          true field is rejected if the bearer caller does not hold it.
 
   UpdatePublicKeyNameRequest:
     docs: |
-      Rename a public-key credential. Key material, ID, type, scope, sign-in
-      eligibility, permissions, generation, and expiry are immutable.
+      Update a public-key credential's name, AgentID owner-claim permissions,
+      or both. At least one field is required. Key material, ID, type, scope,
+      sign-in eligibility, generation, and expiry remain immutable.
     properties:
       name:
-        type: string
+        type: optional<string>
         validation:
           minLength: 1
           maxLength: 256
+      permissions:
+        type: optional<PublicKeyPermissionSelection>
+        docs: |
+          Per-field merge. Omitted fields preserve their current value, false
+          revokes a permission, and true is rejected if the bearer caller does
+          not currently hold that permission.
 
   ListPublicKeysResponse:
     properties:
@@ -163,7 +204,7 @@ types:
       revoked_at: datetime
 
   ApiKeyPermissions:
-    docs: Granular permissions for the API key. When ommitted all permissions are granted. Otherwise, only permissions set to true are granted.
+    docs: Granular permissions for the API key. When omitted all permissions are granted. Otherwise, only permissions set to true are granted.
     properties:
       inbox_read:
         type: optional<boolean>
@@ -273,6 +314,12 @@ types:
       pod_delete:
         type: optional<boolean>
         docs: Delete pods.
+      owner_profile:
+        type: optional<boolean>
+        docs: Allow child AgentID public-key credentials to authorize the `owner_profile` OAuth scope.
+      owner_email:
+        type: optional<boolean>
+        docs: Allow child AgentID public-key credentials to authorize the `owner_email` OAuth scope.
 
   ApiKey:
     properties:
@@ -406,9 +453,12 @@ service:
     updatePublicKeyName:
       method: PATCH
       path: /public-keys/{api_key_id}
-      display-name: Rename Public-Key Credential
+      display-name: Update Public-Key Credential
       docs: |
-        Rename the credential. All security-relevant fields are immutable.
+        Update the credential's name, AgentID owner-claim permissions, or both.
+        Permission changes use per-field merge semantics and cannot grant a
+        permission the bearer caller does not currently hold. The generated SDK
+        method retains its original `updatePublicKeyName` name for compatibility.
         Requires `api_key_update`.
       path-parameters:
         api_key_id:

--- a/fern/pages/core-concepts/permissions.mdx
+++ b/fern/pages/core-concepts/permissions.mdx
@@ -142,6 +142,17 @@ Threads are groupings of messages and have no permissions of their own. Every th
 | `pod_create` | Create pods |
 | `pod_delete` | Delete pods |
 
+### AgentID Owner Claims
+
+These permissions do not grant an API key a new AgentMail REST operation. They
+set the maximum owner-claim authority that the bearer key may delegate to an
+[AgentID public-key credential](/agentid-public-key-authentication).
+
+| Permission | Description |
+| --- | --- |
+| `owner_profile` | Allow a child AgentID public-key credential to authorize the `owner_profile` OAuth scope and its `owner_name` claim |
+| `owner_email` | Allow a child AgentID public-key credential to authorize the `owner_email` OAuth scope and its `owner_email` claim |
+
 ## Code Examples
 
 ### Read-only key
@@ -270,6 +281,8 @@ key = client.api_keys.create(
         "pod_read": True,
         "pod_create": True,
         "pod_delete": True,
+        "owner_profile": True,
+        "owner_email": True,
     }
 )
 ```
@@ -314,6 +327,8 @@ const key = await client.apiKeys.create({
     podRead: true,
     podCreate: true,
     podDelete: true,
+    ownerProfile: true,
+    ownerEmail: true,
   },
 });
 ```
@@ -358,7 +373,9 @@ agentmail api-keys create \
     "api_key_delete": true,
     "pod_read": true,
     "pod_create": true,
-    "pod_delete": true
+    "pod_delete": true,
+    "owner_profile": true,
+    "owner_email": true
   }'
 ```
 </CodeBlocks>
@@ -387,6 +404,7 @@ Copy one of the blocks below into Cursor or Claude for complete Permissions API 
     Metrics: metrics_read
     API Keys: api_key_read, api_key_create, api_key_update, api_key_delete
     Pods: pod_read, pod_create, pod_delete
+    AgentID owner claims: owner_profile, owner_email
 
   Threads have no permissions of their own: thread reads use message_read,
   thread label updates use message_update, and thread deletes use message_delete.
@@ -424,6 +442,7 @@ Copy one of the blocks below into Cursor or Claude for complete Permissions API 
    *   Metrics: metricsRead
    *   API Keys: apiKeyRead, apiKeyCreate, apiKeyUpdate, apiKeyDelete
    *   Pods: podRead, podCreate, podDelete
+   *   AgentID owner claims: ownerProfile, ownerEmail
    *
    * Threads have no permissions of their own: thread reads use messageRead,
    * thread label updates use messageUpdate, and thread deletes use messageDelete.

--- a/fern/pages/guides/agentid-public-key-authentication.mdx
+++ b/fern/pages/guides/agentid-public-key-authentication.mdx
@@ -23,6 +23,7 @@ bearer key or the private key to AgentID.
    keystore.
 2. Export only `{kty: "EC", crv: "P-256", x, y}` and register it at
    `POST /v0/api-keys/public-keys` with an existing AgentMail bearer API key.
+   Optionally select whether the key may disclose owner profile or email claims.
 3. Store the returned `api_key_id` beside the private-key handle. It is the JWS
    `kid`; do not compute or choose it yourself.
 4. For one pending authorization transaction, sign exactly `{jti, inbox_id}`
@@ -79,6 +80,11 @@ class InboxScope(TypedDict):
     id: str
 
 
+class PublicKeyPermissions(TypedDict, total=False):
+    owner_profile: bool
+    owner_email: bool
+
+
 Scope = Union[OrganizationScope, PodScope, InboxScope]
 
 
@@ -103,6 +109,7 @@ def register_agentid_key(
     scope: Optional[Scope] = None,
     name: Optional[str] = None,
     expires_at: Optional[datetime] = None,
+    permissions: Optional[PublicKeyPermissions] = None,
 ):
     request: Dict[str, Any] = {"public_key": public_jwk(private_key)}
     if scope is not None:
@@ -111,6 +118,8 @@ def register_agentid_key(
         request["name"] = name
     if expires_at is not None:
         request["expires_at"] = expires_at
+    if permissions is not None:
+        request["permissions"] = permissions
     return client.api_keys.create_public_key(**request)
 
 
@@ -123,6 +132,7 @@ credential = register_agentid_key(
     private_key,
     name="production signer",
     scope={"type": "inbox", "id": "agent@example.com"},
+    permissions={"owner_profile": True, "owner_email": True},
 )
 
 # Store this mapping in trusted application state.
@@ -153,13 +163,19 @@ function publicJwk(publicKey: KeyObject) {
 async function registerAgentIdKey(
   client: AgentMailClient,
   publicKey: KeyObject,
-  options: { scope?: Scope; name?: string; expiresAt?: Date } = {},
+  options: {
+    scope?: Scope;
+    name?: string;
+    expiresAt?: Date;
+    permissions?: { ownerProfile?: boolean; ownerEmail?: boolean };
+  } = {},
 ) {
   return client.apiKeys.createPublicKey({
     publicKey: publicJwk(publicKey),
     scope: options.scope,
     name: options.name,
     expiresAt: options.expiresAt,
+    permissions: options.permissions,
   });
 }
 
@@ -172,6 +188,7 @@ const client = new AgentMailClient({ apiKey: "YOUR_EXISTING_AGENTMAIL_API_KEY" }
 const credential = await registerAgentIdKey(client, publicKey, {
   name: "production signer",
   scope: { type: "inbox", id: "agent@example.com" },
+  permissions: { ownerProfile: true, ownerEmail: true },
 });
 
 const keyRecord = {
@@ -207,8 +224,37 @@ or sibling.
 For `expires_at`, omission inherits the registering bearer credential's expiry.
 If that bearer does not expire, the public-key credential does not expire. An
 explicit expiry must be in the future and cannot be later than the creator's
-expiry. Scope, key material, AgentID eligibility, and expiry are immutable after
-registration; only `name` can be patched.
+expiry. Scope, key material, AgentID eligibility, generation, and expiry are
+immutable after registration. The credential's `name` and owner-claim
+permissions can be patched.
+
+## Owner claim permissions
+
+Public-key credentials have two permissions that apply only during AgentID
+sign-in:
+
+| Permission | OAuth scope | Claim |
+| --- | --- | --- |
+| `owner_profile` | `owner_profile` | `owner_name` |
+| `owner_email` | `owner_email` | `owner_email` |
+
+These permissions do not grant access to AgentMail REST endpoints or expose the
+current organization owner through the AgentMail API. They only control whether
+the public-key credential may approve the corresponding scope when a registered
+AgentID client asks for it.
+
+Omitting `permissions` during registration inherits the bearer caller's
+effective owner-permission ceiling. Supplying a permissions object selects an
+exact subset: a missing or `false` field is disabled, and the API rejects a
+`true` field that the bearer caller does not hold. Create and list responses
+always return both booleans explicitly.
+
+PATCH uses per-field merge semantics. An omitted field preserves its current
+value, `false` revokes it, and `true` restores it only when the bearer caller
+currently holds that permission. Removing a permission immediately prevents
+the credential from authorizing that owner scope and invalidates existing
+UserInfo access for grants that carry it. Historical client activity keeps the
+sign-in event but suppresses the affected owner claim.
 
 ## Sign and submit one approval
 
@@ -311,7 +357,7 @@ stored public-key credential, verifies the signature, validates the transaction,
 and rechecks the key, organization, scope, inbox, generation, and expiry before
 committing one approval. Concurrent or repeated submissions have one winner.
 
-## List, rename, revoke, and rotate
+## List, update, revoke, and rotate
 
 The generated clients for this contract expose dedicated lifecycle methods.
 Legacy `api_keys.list`, `api_keys.create`, and `api_keys.delete` remain
@@ -323,10 +369,12 @@ bearer-only and have no public-key request member.
 # Public-key list results never include bearer credentials.
 page = client.api_keys.list_public_keys(limit=20)
 
-# Name is the only mutable property.
-renamed = client.api_keys.update_public_key_name(
+# The historical SDK method name is retained for compatibility. It can update
+# the name, owner permissions, or both.
+updated = client.api_keys.update_public_key_name(
     credential.api_key_id,
     name="production signer 2026-08",
+    permissions={"owner_email": False},
 )
 
 # Rotate by creating the replacement first, deploying its new kid, then deleting old.
@@ -339,9 +387,11 @@ client.api_keys.revoke_public_key(credential.api_key_id)
 // Public-key list results never include bearer credentials.
 const page = await client.apiKeys.listPublicKeys({ limit: 20 });
 
-// Name is the only mutable property.
-const renamed = await client.apiKeys.updatePublicKeyName(credential.apiKeyId, {
+// The historical SDK method name is retained for compatibility. It can update
+// the name, owner permissions, or both.
+const updated = await client.apiKeys.updatePublicKeyName(credential.apiKeyId, {
   name: "production signer 2026-08",
+  permissions: { ownerEmail: false },
 });
 
 // Rotate by creating the replacement first, deploying its new kid, then deleting old.


### PR DESCRIPTION
## Summary

Follow-up to agentmail-to/agentmail-api#715 and the GA gate in `plans/AGENTID_OWNER_EMAIL.md`.

- add dedicated Fern request and response models for the `owner_profile` and `owner_email` permissions on AgentID public-key credentials
- expose permission selection on public-key registration and permission updates on the existing PATCH route
- document inheritance, delegation ceilings, explicit response booleans, per-field PATCH merge semantics, and immediate revocation behavior
- add the two owner permissions to the bearer API-key contract and permissions reference
- update the public-key guide and changelog examples

## Why

The merged API now accepts owner permissions when public-key credentials are created or updated and always returns both permission booleans. The published Fern contract still described permissions as server-owned and immutable, so generated clients could not exercise the deployed API safely.

## SDK compatibility

The TypeScript SDK has already shipped the generated `updatePublicKeyName` method. This PR intentionally keeps the Fern endpoint key and generated method name stable while expanding its request to update the name, owner permissions, or both. That avoids deleting an already-released method.

## Developer impact

Generated Python and TypeScript clients can independently allow or block `owner_profile` and `owner_email` at credential creation and through the existing update method. Public-key responses expose both booleans explicitly, and bearer-key permission models expose the delegation ceiling used by public-key creation and update.

## Root cause

The original public-key docs contract landed before the owner-scope permission storage and management paths in API PR 2a. PR 3 activated those scopes, leaving the Fern schema one delivery step behind the runtime contract.

## Validation

- Fern Check CI: passed
- docs preview: passed
- OpenAPI generation and API changelog diff: passed
- TypeScript: `tsc --noEmit --typeRoots /Users/shabs/Dev/agentmail/agentmail-docs/node_modules/@types`
- YAML parse: all `fern/**/*.yml` files load successfully with Ruby Psych
- `git diff --check`
- compatibility inspection against released `agentmail-node` 0.5.18 confirms `updatePublicKeyName` is already public and remains stable
