### PR TITLE
fix docs rendering by removing Reo script

### DIFF
--- a/fern/custom.js
+++ b/fern/custom.js
@@ -6,17 +6,3 @@
   link.href = "/llms.txt";
   document.head.appendChild(link);
 })();
-
-// Reo.dev tracking script
-!(function () {
-  var e, t, n;
-  (e = "b38ba24420b76f6"),
-    (t = function () {
-      Reo.init({ clientID: "b38ba24420b76f6" });
-    }),
-    ((n = document.createElement("script")).src =
-      "https://static.reo.dev/" + e + "/reo.js"),
-    (n.defer = !0),
-    (n.onload = t),
-    document.head.appendChild(n);
-})();


### PR DESCRIPTION
## What changed

- remove the Reo.dev loader from the global Fern custom JavaScript
- keep the existing `llms.txt` discoverability helper intact

## Why

Authored MDX pages on the public docs currently fail with `Function yaml.safeLoad is removed in js-yaml 4`. Isolated Fern previews showed that the failure is triggered by the Reo loader in `fern/custom.js`: the original script reproduces the site-wide renderer error, while the same repository and pinned Fern version render normally once only that loader is removed.

## Impact

- restores rendered content on authored docs pages such as Introduction and Quickstart
- disables Reo.dev tracking until it can be reintroduced through a compatible integration path
- does not change the Fern CLI version, instance configuration, page content, or `llms.txt` behavior

## Validation

- `npm run lint`
- `fern check --warnings` (0 errors; pre-existing endpoint-conflict and missing-redirect warnings remain)
- Fern preview: https://agentmail-preview-61609cc0-27bf-4706-a65a-1b9125071ac8.docs.buildwithfern.com
- browser verification on `/introduction` and `/quickstart`: content rendered, no renderer error, and no console warnings/errors
